### PR TITLE
fix(parser): support TikTok /photo/ URLs in parseShortcodeFromUrl

### DIFF
--- a/src/lib/ensembledata/client.ts
+++ b/src/lib/ensembledata/client.ts
@@ -126,7 +126,7 @@ export function parseShortcodeFromUrl(
   const path = parsed.pathname;
   switch (platform.toLowerCase()) {
     case "tiktok": {
-      const m = path.match(/\/(?:video|v)\/(\d+)/);
+      const m = path.match(/\/(?:video|v|photo)\/(\d+)/);
       return m ? m[1] : null;
     }
     case "instagram": {
@@ -592,6 +592,9 @@ function mapMetrics(platform: Platform, body: unknown): Metrics {
 //
 // parseShortcodeFromUrl('https://www.tiktok.com/@number.1.angel10/video/7627616681170324758', 'tiktok')
 //   -> '7627616681170324758'
+//
+// parseShortcodeFromUrl('https://www.tiktok.com/@starcashdoc/photo/7615333991847120142', 'tiktok')
+//   -> '7615333991847120142'
 //
 // parseShortcodeFromUrl('https://x.com/xcxsource/status/2037213168209191391', 'twitter')
 //   -> '2037213168209191391'


### PR DESCRIPTION
Extends the TikTok regex in parseShortcodeFromUrl to match /photo/<id>
in addition to /video/<id> and /v/<id>.

TikTok photo carousels use the same numeric ID format as videos and
EnsembleData's TikTok endpoint accepts the full URL, so no API-side
changes needed. Unblocks ~25 rows of the Star Cash fan_edits import
that were rejecting with parse_failure.

Verified:
- npx tsc --noEmit clean for this file (13 pre-existing errors in 
  unrelated files, all missing-module — separate issue)
- Both call sites (importer + Discover-tab add flow) inherit the fix
- No existing unit tests for parseShortcodeFromUrl; will verify 
  empirically via Star Cash re-import