### PR TITLE
partner-admin access: invite email + navbar surfacing

### DIFF
--- a/src/app/api/admin/partners/[id]/members/route.ts
+++ b/src/app/api/admin/partners/[id]/members/route.ts
@@ -23,6 +23,10 @@ import { NextResponse, type NextRequest } from "next/server";
 import { requireSuperAdmin } from "@/lib/dal";
 import { createServiceRoleClient } from "@/lib/supabase/service";
 import { enforce } from "@/lib/ratelimit";
+import {
+  sendPartnerInviteEmail,
+  type PartnerInviteRole,
+} from "@/lib/email/partner-invite";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -86,9 +90,10 @@ export async function POST(
   }
 
   const supabase = createServiceRoleClient();
+  // name + slug are needed for the invite-notification email below.
   const { data: partner } = await supabase
     .from("partners")
-    .select("id")
+    .select("id, name, slug")
     .eq("id", id)
     .maybeSingle();
   if (!partner) {
@@ -151,6 +156,34 @@ export async function POST(
       );
     }
     memberId = inserted.id as string;
+  }
+
+  // Fire-and-forget invite notification on BOTH new-insert and
+  // resurrect (clear-deleted) paths — a resurrected user is a
+  // deliberate re-add and should hear about it the same way a
+  // first-time add does. Synchronous direct-send via
+  // sendBrandedEmail; matches welcome / title-request-alert. A
+  // failure must NOT fail the API response — the partner_users
+  // row is already committed and is the source of truth. Log
+  // loudly so the super-admin can resend by re-adding if needed.
+  try {
+    const sendResult = await sendPartnerInviteEmail({
+      to: email,
+      partnerName: partner.name as string,
+      partnerSlug: partner.slug as string,
+      role: role as PartnerInviteRole,
+    });
+    if (!sendResult.ok) {
+      console.error(
+        `[partner-invite] send failed for ${email} on partner=${id} role=${role}: ${sendResult.error}`,
+      );
+    }
+  } catch (err) {
+    console.error(
+      `[partner-invite] send threw for ${email} on partner=${id} role=${role}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
 
   // Re-read via the RPC to return the member row in the same shape

--- a/src/components/AccountMenu.tsx
+++ b/src/components/AccountMenu.tsx
@@ -4,12 +4,16 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
+import type { PartnerMembership } from "@/lib/dal";
 
 type Props = {
   email: string;
   handle: string | null;
   displayName: string | null;
   avatarUrl: string | null;
+  // Optional so existing callers don't break. Empty/undefined → no
+  // partner section is rendered.
+  partnerMemberships?: PartnerMembership[];
 };
 
 function initial(text: string): string {
@@ -21,7 +25,9 @@ export default function AccountMenu({
   handle,
   displayName,
   avatarUrl,
+  partnerMemberships,
 }: Props) {
+  const memberships = partnerMemberships ?? [];
   const [open, setOpen] = useState(false);
   const [pending, setPending] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
@@ -99,6 +105,28 @@ export default function AccountMenu({
           >
             Account
           </Link>
+          {memberships.length > 0 && (
+            <>
+              <div className="my-1 border-t border-white/5" />
+              <p className="px-4 pt-2 pb-1 text-caption text-moonbeem-ink-subtle">
+                Your partners
+              </p>
+              {memberships.map((m) => (
+                <Link
+                  key={m.partner_id}
+                  href={`/p/${m.partner_slug}/dashboard`}
+                  onClick={() => setOpen(false)}
+                  className="flex items-center justify-between gap-3 px-4 py-2 text-body-sm text-moonbeem-ink hover:bg-white/5 transition-colors"
+                >
+                  <span className="truncate">{m.partner_name}</span>
+                  <span className="shrink-0 text-caption text-moonbeem-ink-subtle">
+                    {m.role}
+                  </span>
+                </Link>
+              ))}
+              <div className="my-1 border-t border-white/5" />
+            </>
+          )}
           <button
             type="button"
             disabled={pending}

--- a/src/components/PartnersNavDropdown.tsx
+++ b/src/components/PartnersNavDropdown.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+// Top-bar dropdown for users who are members of two or more partner
+// teams. Single-membership users see a plain link inline in TopNav
+// instead — this component is only mounted when memberships.length
+// >= 2. Click-outside-to-close, ESC-to-close. Same visual treatment
+// as AccountMenu's panel for visual coherence on the right side of
+// the header.
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import type { PartnerMembership } from "@/lib/dal";
+
+type Props = { memberships: PartnerMembership[] };
+
+export default function PartnersNavDropdown({ memberships }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    function onClick(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, []);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="text-body-sm text-moonbeem-ink-muted hover:text-moonbeem-ink transition-colors"
+      >
+        Your partners ▾
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-2 w-64 rounded-xl bg-moonbeem-black/95 backdrop-blur-md border border-white/10 shadow-2xl shadow-black/50 py-2 z-30"
+        >
+          <p className="px-4 pb-2 text-caption text-moonbeem-ink-subtle border-b border-white/5">
+            Your partners
+          </p>
+          {memberships.map((m) => (
+            <Link
+              key={m.partner_id}
+              href={`/p/${m.partner_slug}/dashboard`}
+              onClick={() => setOpen(false)}
+              className="flex items-center justify-between gap-3 px-4 py-2 text-body-sm text-moonbeem-ink hover:bg-white/5 transition-colors"
+            >
+              <span className="truncate">{m.partner_name}</span>
+              <span className="shrink-0 text-caption text-moonbeem-ink-subtle">
+                {m.role}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -3,11 +3,19 @@ import Link from "next/link";
 import { getCurrentProfile } from "@/lib/dal";
 import AccountMenu from "./AccountMenu";
 import MobileNavMenu from "./MobileNavMenu";
+import PartnersNavDropdown from "./PartnersNavDropdown";
 import SearchBar from "./SearchBar";
 
 export default async function TopNav() {
   const profile = await getCurrentProfile();
   const isSuperAdmin = profile?.role === "super_admin";
+  const memberships = profile?.partnerMemberships ?? [];
+  // UX rules per spec:
+  //   0 memberships → render nothing extra (existing state).
+  //   1 membership  → a single inline link "<Partner> dashboard".
+  //   2+            → "Your partners ▾" dropdown.
+  const singleMembership = memberships.length === 1 ? memberships[0] : null;
+  const showPartnersDropdown = memberships.length >= 2;
 
   return (
     <header className="sticky top-0 z-20 h-16 border-b border-white/5 bg-moonbeem-black/80 backdrop-blur-md">
@@ -49,6 +57,17 @@ export default async function TopNav() {
               For You
             </Link>
           )}
+          {singleMembership && (
+            <Link
+              href={`/p/${singleMembership.partner_slug}/dashboard`}
+              className="text-body-sm text-moonbeem-ink-muted hover:text-moonbeem-ink transition-colors"
+            >
+              {singleMembership.partner_name} dashboard
+            </Link>
+          )}
+          {showPartnersDropdown && (
+            <PartnersNavDropdown memberships={memberships} />
+          )}
           {isSuperAdmin && (
             <Link
               href="/admin"
@@ -70,6 +89,7 @@ export default async function TopNav() {
               handle={profile.handle}
               displayName={profile.displayName}
               avatarUrl={profile.avatarUrl}
+              partnerMemberships={memberships}
             />
           ) : (
             <Link

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -1,6 +1,18 @@
 import { cache } from "react";
 import { notFound, redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+
+// Partner-team memberships attached to the per-request profile. Used
+// by TopNav + AccountMenu to surface partner-dashboard links. Loaded
+// once per profile cache hit; consumers re-render based on the array
+// shape (length 0 / 1 / 2+).
+export type PartnerMembership = {
+  partner_id: string;
+  partner_slug: string;
+  partner_name: string;
+  role: string;
+};
 
 export const verifySession = cache(async () => {
   const supabase = await createClient();
@@ -34,6 +46,50 @@ export const getCurrentProfile = cache(async () => {
     .select("id, role, handle, display_name, avatar_url")
     .eq("id", user.id)
     .maybeSingle();
+
+  // Partner-team memberships for the navbar. partner_users has RLS
+  // enabled with no policies, so reads go through the service-role
+  // client — same convention as /p/[slug]/dashboard's membership
+  // check. Two bounded queries (memberships, then partners by id) —
+  // NOT N+1 (the second query is one .in() lookup, not one per
+  // partner). Most users have zero memberships → only the first
+  // query runs.
+  const service = createServiceRoleClient();
+  const { data: memRows } = await service
+    .from("partner_users")
+    .select("partner_id, role")
+    .eq("user_id", user.id)
+    .is("deleted_at", null)
+    .order("created_at", { ascending: true });
+
+  let partnerMemberships: PartnerMembership[] = [];
+  if (memRows && memRows.length > 0) {
+    const partnerIds = memRows.map((m) => m.partner_id as string);
+    const { data: partners } = await service
+      .from("partners")
+      .select("id, slug, name")
+      .in("id", partnerIds);
+    const byId = new Map<string, { slug: string; name: string }>();
+    for (const p of partners ?? []) {
+      byId.set(p.id as string, {
+        slug: p.slug as string,
+        name: p.name as string,
+      });
+    }
+    partnerMemberships = memRows
+      .map((m) => {
+        const p = byId.get(m.partner_id as string);
+        if (!p) return null;
+        return {
+          partner_id: m.partner_id as string,
+          partner_slug: p.slug,
+          partner_name: p.name,
+          role: m.role as string,
+        };
+      })
+      .filter((x): x is PartnerMembership => x !== null);
+  }
+
   return {
     userId: user.id,
     email: user.email ?? "",
@@ -41,6 +97,7 @@ export const getCurrentProfile = cache(async () => {
     handle: (data?.handle ?? null) as string | null,
     displayName: (data?.display_name ?? null) as string | null,
     avatarUrl: (data?.avatar_url ?? null) as string | null,
+    partnerMemberships,
   };
 });
 

--- a/src/lib/email/partner-invite.ts
+++ b/src/lib/email/partner-invite.ts
@@ -1,0 +1,127 @@
+// Partner-team invite notification. Fires from POST
+// /api/admin/partners/[id]/members when a super-admin adds a user
+// (or re-adds a soft-removed user) as 'admin' or 'viewer' of a
+// partner.
+//
+// The user already has a Moonbeem account by the time we reach
+// this code path (find_auth_user_by_email guards the route), so
+// this is a NOTIFICATION about the new role, not a signup
+// invitation. There is no token, no acceptance step — the
+// membership row is already live in partner_users when the email
+// goes out.
+//
+// Direct send via sendBrandedEmail, matching welcome.ts and
+// title-request-alert.ts. Not queued — partner invites are low
+// volume and one-shot; the existing email_queue is shaped for
+// title-content notifications (NOT NULL title_id + content_type
+// CHECK) and cannot carry this payload. If volume ever justifies
+// retry resilience for partner invites, queueing is a clean
+// future migration.
+//
+// Fail-soft contract: the API route wraps the call in try/catch
+// and logs on failure. A failed send must NOT fail the API
+// response — the partner_users row is the source of truth; the
+// super-admin can resend by re-adding (which lands on the
+// resurrect path and re-fires this notification).
+
+import { getOrigin } from "./origin";
+import { sendBrandedEmail, type SendResult } from "./send";
+import { escapeHtml, paragraph, signoff, wrap } from "./components";
+
+export type PartnerInviteRole = "admin" | "viewer";
+
+type BuildArgs = {
+  partnerName: string;
+  partnerSlug: string;
+  role: PartnerInviteRole;
+  origin: string;
+};
+
+function roleBlurb(
+  role: PartnerInviteRole,
+  partnerNameSafe: string,
+): string {
+  if (role === "admin") {
+    return `You've been added as an admin of ${partnerNameSafe} on moonbeem. You can manage campaigns and rates from your dashboard.`;
+  }
+  return `You've been added as a viewer of ${partnerNameSafe} on moonbeem. You can see campaigns and analytics from your dashboard.`;
+}
+
+function roleBlurbPlain(
+  role: PartnerInviteRole,
+  partnerName: string,
+): string {
+  if (role === "admin") {
+    return `You've been added as an admin of ${partnerName} on moonbeem. You can manage campaigns and rates from your dashboard.`;
+  }
+  return `You've been added as a viewer of ${partnerName} on moonbeem. You can see campaigns and analytics from your dashboard.`;
+}
+
+export function buildPartnerInviteEmail(args: BuildArgs): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const { partnerName, partnerSlug, role, origin } = args;
+  const escapedName = escapeHtml(partnerName);
+  const dashboardUrl =
+    `${origin}/p/${encodeURIComponent(partnerSlug)}/dashboard`;
+
+  const innerHtml = [
+    paragraph("Hey Beemer,"),
+    paragraph(roleBlurb(role, escapedName)),
+    paragraph(
+      `Visit your dashboard at <a href="${dashboardUrl}" style="color:#011754;">${dashboardUrl}</a> to get started.`,
+    ),
+    signoff(),
+  ].join("\n");
+
+  const html = wrap({
+    innerHtml,
+    origin,
+    reasonLine:
+      `You're receiving this because you were added to ${escapedName}'s partner team on Moonbeem.`,
+  });
+
+  const text = [
+    "Hey Beemer,",
+    "",
+    roleBlurbPlain(role, partnerName),
+    "",
+    `Visit your dashboard at ${dashboardUrl} to get started.`,
+    "",
+    "More soon,",
+    "Team Moonbeem",
+  ].join("\n");
+
+  return {
+    subject: `You've been added to ${partnerName} on Moonbeem`,
+    html,
+    text,
+  };
+}
+
+// Fail-soft sender used by the API route. Looks like
+// sendWelcomeEmail and sendTitleRequestAlert — minimal lookup,
+// dispatches via sendBrandedEmail, returns SendResult so the
+// caller can route success/failure.
+export async function sendPartnerInviteEmail(args: {
+  to: string;
+  partnerName: string;
+  partnerSlug: string;
+  role: PartnerInviteRole;
+}): Promise<SendResult> {
+  const { subject, html, text } = buildPartnerInviteEmail({
+    partnerName: args.partnerName,
+    partnerSlug: args.partnerSlug,
+    role: args.role,
+    origin: getOrigin(),
+  });
+
+  return sendBrandedEmail({
+    to: args.to,
+    subject,
+    html,
+    text,
+  });
+}


### PR DESCRIPTION
Two slices, addressing the two issues Rohan reported on 5/20 (no invite email arrived, no partner-admin panel visible after login).

## Slice 1 — invite email (commit `ef3617a`)

Send a notification email when a user is added as a partner-team member via `POST /api/admin/partners/[id]/members`. New `src/lib/email/partner-invite.ts` mirrors `welcome.ts` and `title-request-alert.ts` (direct send via `sendBrandedEmail`; the existing `email_queue` is title-scoped and can't carry partner-invite payloads, see file header for the rationale). Fires on both the new-insert and the soft-deleted-resurrect paths; the `409 already_member` early return does NOT fire the email. Fail-soft: a Resend failure logs `[partner-invite]` but never fails the API response.

Email voice mirrors `welcome.ts`: "Hey Beemer," opener, two short paragraphs, role-conditional wording (admin/viewer), inline dashboard link, "More soon, Team Moonbeem" sign-off.

## Slice 2 — navbar partner-membership surfacing (commit `f0fe260`)

`getCurrentProfile()` now loads partner_users memberships (service-role read, two bounded queries, NOT N+1, cached per-request via React.cache). TopNav renders memberships per UX rules:
- `0` memberships → render nothing extra (existing state).
- `1` → inline `"<Partner> dashboard"` link next to "For You".
- `2+` → `"Your partners ▾"` dropdown via new `PartnersNavDropdown` client component.

`AccountMenu` adds a "Your partners" section between Account and Sign out so the avatar dropdown covers mobile/narrow viewports where the desktop nav is hidden. `PartnerMembership` type lives in `dal.ts` and is `import type`'d into the client components — no server code in the client bundle.

`MobileNavMenu` intentionally untouched; mobile users surface partners via the avatar dropdown.

## Scope

No migrations, no changes to `/p/[slug]/dashboard` or the creator withdraw rail. Additive profile field; optional `AccountMenu` prop — no existing callers break. `npm run build` clean on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)