### PR TITLE
partner-admin nav: unify into single Admin dropdown + mobile parity

### DIFF
--- a/src/components/AccountMenu.tsx
+++ b/src/components/AccountMenu.tsx
@@ -4,16 +4,12 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
-import type { PartnerMembership } from "@/lib/dal";
 
 type Props = {
   email: string;
   handle: string | null;
   displayName: string | null;
   avatarUrl: string | null;
-  // Optional so existing callers don't break. Empty/undefined → no
-  // partner section is rendered.
-  partnerMemberships?: PartnerMembership[];
 };
 
 function initial(text: string): string {
@@ -25,9 +21,7 @@ export default function AccountMenu({
   handle,
   displayName,
   avatarUrl,
-  partnerMemberships,
 }: Props) {
-  const memberships = partnerMemberships ?? [];
   const [open, setOpen] = useState(false);
   const [pending, setPending] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
@@ -105,28 +99,6 @@ export default function AccountMenu({
           >
             Account
           </Link>
-          {memberships.length > 0 && (
-            <>
-              <div className="my-1 border-t border-white/5" />
-              <p className="px-4 pt-2 pb-1 text-caption text-moonbeem-ink-subtle">
-                Your partners
-              </p>
-              {memberships.map((m) => (
-                <Link
-                  key={m.partner_id}
-                  href={`/p/${m.partner_slug}/dashboard`}
-                  onClick={() => setOpen(false)}
-                  className="flex items-center justify-between gap-3 px-4 py-2 text-body-sm text-moonbeem-ink hover:bg-white/5 transition-colors"
-                >
-                  <span className="truncate">{m.partner_name}</span>
-                  <span className="shrink-0 text-caption text-moonbeem-ink-subtle">
-                    {m.role}
-                  </span>
-                </Link>
-              ))}
-              <div className="my-1 border-t border-white/5" />
-            </>
-          )}
           <button
             type="button"
             disabled={pending}

--- a/src/components/AdminNavDropdown.tsx
+++ b/src/components/AdminNavDropdown.tsx
@@ -1,19 +1,35 @@
 "use client";
 
-// Top-bar dropdown for users who are members of two or more partner
-// teams. Single-membership users see a plain link inline in TopNav
-// instead — this component is only mounted when memberships.length
-// >= 2. Click-outside-to-close, ESC-to-close. Same visual treatment
-// as AccountMenu's panel for visual coherence on the right side of
-// the header.
+// Unified top-bar "Admin" dropdown. Replaces the previous standalone
+// super-admin "Admin" link AND the PartnersNavDropdown (slice 2).
+// One nav entry for every admin/membership combination — super_admin
+// only, partner only, both, or none.
+//
+// Caller (TopNav) decides whether to mount this at all: render only
+// when `isSuperAdmin || memberships.length > 0`. If neither
+// condition holds, the component has nothing useful to show.
+//
+// Section order in the panel: Super admin row first (if applicable),
+// then a hairline divider when both sections present, then one
+// partner-dashboard row per membership in order received.
+//
+// Click-outside-to-close + ESC-to-close, same as AccountMenu. Always
+// a dropdown — even for a single entry — so the visual shape is
+// consistent across role combinations.
 
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import type { PartnerMembership } from "@/lib/dal";
 
-type Props = { memberships: PartnerMembership[] };
+type Props = {
+  isSuperAdmin: boolean;
+  memberships: PartnerMembership[];
+};
 
-export default function PartnersNavDropdown({ memberships }: Props) {
+export default function AdminNavDropdown({
+  isSuperAdmin,
+  memberships,
+}: Props) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
 
@@ -32,6 +48,8 @@ export default function PartnersNavDropdown({ memberships }: Props) {
     };
   }, []);
 
+  const showDivider = isSuperAdmin && memberships.length > 0;
+
   return (
     <div ref={ref} className="relative">
       <button
@@ -39,18 +57,25 @@ export default function PartnersNavDropdown({ memberships }: Props) {
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
-        className="text-body-sm text-moonbeem-ink-muted hover:text-moonbeem-ink transition-colors"
+        className="text-body-sm text-moonbeem-pink hover:opacity-80 transition-opacity"
       >
-        Your partners ▾
+        Admin ▾
       </button>
       {open && (
         <div
           role="menu"
           className="absolute right-0 top-full mt-2 w-64 rounded-xl bg-moonbeem-black/95 backdrop-blur-md border border-white/10 shadow-2xl shadow-black/50 py-2 z-30"
         >
-          <p className="px-4 pb-2 text-caption text-moonbeem-ink-subtle border-b border-white/5">
-            Your partners
-          </p>
+          {isSuperAdmin && (
+            <Link
+              href="/admin"
+              onClick={() => setOpen(false)}
+              className="block px-4 py-2 text-body-sm text-moonbeem-pink hover:bg-white/5 transition-colors"
+            >
+              Super admin
+            </Link>
+          )}
+          {showDivider && <div className="my-1 border-t border-white/5" />}
           {memberships.map((m) => (
             <Link
               key={m.partner_id}
@@ -58,7 +83,7 @@ export default function PartnersNavDropdown({ memberships }: Props) {
               onClick={() => setOpen(false)}
               className="flex items-center justify-between gap-3 px-4 py-2 text-body-sm text-moonbeem-ink hover:bg-white/5 transition-colors"
             >
-              <span className="truncate">{m.partner_name}</span>
+              <span className="truncate">{m.partner_name} dashboard</span>
               <span className="shrink-0 text-caption text-moonbeem-ink-subtle">
                 {m.role}
               </span>

--- a/src/components/MobileNavMenu.tsx
+++ b/src/components/MobileNavMenu.tsx
@@ -3,10 +3,18 @@
 // Mobile hamburger nav. Below md, the desktop <nav> in TopNav is
 // display:none, so this provides the navigation affordance.
 //
-// Auth handling: TopNav (server) computes the booleans once and
-// passes them in. We deliberately do NOT call getCurrentProfile()
-// or any auth helper here — one source of truth for "is this user
-// an admin" lives in TopNav.
+// Auth handling: TopNav (server) computes the booleans + membership
+// list once and passes them in. We deliberately do NOT call
+// getCurrentProfile() or any auth helper here — one source of truth
+// for "what admin surfaces does this user see" lives in TopNav.
+//
+// Admin section mirrors the desktop AdminNavDropdown — same row
+// composition (Super admin + per-partner rows), same divider when
+// both sections are present, same visual weight (Super admin in
+// pink, partner rows in ink with muted role tags on the right).
+// Flat-listed here instead of nested-in-a-dropdown because a
+// dropdown inside a hamburger is awkward; the hamburger is
+// already a panel.
 //
 // Overlay pattern (matches ConsentSettingsModal + AccountMenu +
 // FanEditModal conventions): role="dialog" root, click-on-backdrop
@@ -16,13 +24,21 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import type { PartnerMembership } from "@/lib/dal";
 
 type Props = {
   showForYou: boolean;
-  showAdmin: boolean;
+  isSuperAdmin: boolean;
+  memberships: PartnerMembership[];
 };
 
-export default function MobileNavMenu({ showForYou, showAdmin }: Props) {
+export default function MobileNavMenu({
+  showForYou,
+  isSuperAdmin,
+  memberships,
+}: Props) {
+  const showAdminSection = isSuperAdmin || memberships.length > 0;
+  const showAdminDivider = isSuperAdmin && memberships.length > 0;
   const [open, setOpen] = useState(false);
 
   // ESC closes. Listener only attached while open so non-menu
@@ -105,14 +121,36 @@ export default function MobileNavMenu({ showForYou, showAdmin }: Props) {
                   For You
                 </Link>
               )}
-              {showAdmin && (
-                <Link
-                  href="/admin"
-                  onClick={() => setOpen(false)}
-                  className="rounded-md px-3 py-3 text-body text-moonbeem-pink hover:bg-white/5 hover:opacity-80 transition-opacity"
-                >
-                  Admin
-                </Link>
+              {showAdminSection && (
+                <>
+                  {isSuperAdmin && (
+                    <Link
+                      href="/admin"
+                      onClick={() => setOpen(false)}
+                      className="rounded-md px-3 py-3 text-body text-moonbeem-pink hover:bg-white/5 hover:opacity-80 transition-opacity"
+                    >
+                      Super admin
+                    </Link>
+                  )}
+                  {showAdminDivider && (
+                    <div className="my-1 border-t border-white/5" />
+                  )}
+                  {memberships.map((m) => (
+                    <Link
+                      key={m.partner_id}
+                      href={`/p/${m.partner_slug}/dashboard`}
+                      onClick={() => setOpen(false)}
+                      className="flex items-center justify-between gap-3 rounded-md px-3 py-3 text-body text-moonbeem-ink hover:bg-white/5 transition-colors"
+                    >
+                      <span className="truncate">
+                        {m.partner_name} dashboard
+                      </span>
+                      <span className="shrink-0 text-caption text-moonbeem-ink-subtle">
+                        {m.role}
+                      </span>
+                    </Link>
+                  ))}
+                </>
               )}
             </nav>
           </div>

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -3,19 +3,18 @@ import Link from "next/link";
 import { getCurrentProfile } from "@/lib/dal";
 import AccountMenu from "./AccountMenu";
 import MobileNavMenu from "./MobileNavMenu";
-import PartnersNavDropdown from "./PartnersNavDropdown";
+import AdminNavDropdown from "./AdminNavDropdown";
 import SearchBar from "./SearchBar";
 
 export default async function TopNav() {
   const profile = await getCurrentProfile();
   const isSuperAdmin = profile?.role === "super_admin";
   const memberships = profile?.partnerMemberships ?? [];
-  // UX rules per spec:
-  //   0 memberships → render nothing extra (existing state).
-  //   1 membership  → a single inline link "<Partner> dashboard".
-  //   2+            → "Your partners ▾" dropdown.
-  const singleMembership = memberships.length === 1 ? memberships[0] : null;
-  const showPartnersDropdown = memberships.length >= 2;
+  // Unified "Admin" dropdown — visible when the user is super_admin
+  // OR has at least one partner membership. One nav slot for every
+  // role combination; the dropdown's contents differ but the trigger
+  // is always the same.
+  const showAdminDropdown = isSuperAdmin || memberships.length > 0;
 
   return (
     <header className="sticky top-0 z-20 h-16 border-b border-white/5 bg-moonbeem-black/80 backdrop-blur-md">
@@ -40,7 +39,11 @@ export default async function TopNav() {
             trigger; the panel is only opened on mobile). Auth
             booleans are computed once above and passed in — no
             second admin check. */}
-        <MobileNavMenu showForYou={!!profile} showAdmin={isSuperAdmin} />
+        <MobileNavMenu
+          showForYou={!!profile}
+          isSuperAdmin={isSuperAdmin}
+          memberships={memberships}
+        />
 
         <nav className="hidden items-center gap-4 md:flex">
           <Link
@@ -57,24 +60,11 @@ export default async function TopNav() {
               For You
             </Link>
           )}
-          {singleMembership && (
-            <Link
-              href={`/p/${singleMembership.partner_slug}/dashboard`}
-              className="text-body-sm text-moonbeem-ink-muted hover:text-moonbeem-ink transition-colors"
-            >
-              {singleMembership.partner_name} dashboard
-            </Link>
-          )}
-          {showPartnersDropdown && (
-            <PartnersNavDropdown memberships={memberships} />
-          )}
-          {isSuperAdmin && (
-            <Link
-              href="/admin"
-              className="text-body-sm text-moonbeem-pink hover:opacity-80 transition-opacity"
-            >
-              Admin
-            </Link>
+          {showAdminDropdown && (
+            <AdminNavDropdown
+              isSuperAdmin={isSuperAdmin}
+              memberships={memberships}
+            />
           )}
         </nav>
 
@@ -89,7 +79,6 @@ export default async function TopNav() {
               handle={profile.handle}
               displayName={profile.displayName}
               avatarUrl={profile.avatarUrl}
-              partnerMemberships={memberships}
             />
           ) : (
             <Link


### PR DESCRIPTION
Follow-up to PR #15. The unified design replaces both the standalone super-admin "Admin" link and the slice-2 partner-link rendering with one nav slot.

## Desktop

- **New `AdminNavDropdown.tsx`** — single top-bar entry "Admin ▾" (violet/pink). Mounted when `isSuperAdmin || memberships.length > 0`. Dropdown contents:
  - "Super admin" row (pink) → `/admin` if `isSuperAdmin`.
  - One row per partner membership ("<Partner> dashboard" + role tag on the right) → `/p/<slug>/dashboard`.
  - Hairline divider between sections when both are present.
- **`TopNav.tsx`** replaces the dual entries with one `AdminNavDropdown` mount.
- **`AccountMenu.tsx`** loses the "Your partners" section + the `partnerMemberships` prop. Returns to its pre-slice-2 shape.
- **`PartnersNavDropdown.tsx`** removed (renamed to `AdminNavDropdown.tsx`, git rename detected — 51% similarity).

## Mobile

- **`MobileNavMenu.tsx`** takes `isSuperAdmin` + `memberships` instead of the prior single `showAdmin` boolean. Renders the same admin section in the hamburger — flat-listed (nested dropdown inside a hamburger is awkward; the hamburger is already a panel). Same row composition, same divider rule, same visual weight as the desktop dropdown.
- Closes the mobile-only regression that this unify would otherwise have introduced for partner-admin-only users (no longer visible in `AccountMenu` after slice 2's "Your partners" section was removed).

## Render cases

| User | Desktop trigger | Dropdown contents | Mobile hamburger |
|---|---|---|---|
| super_admin + 1 partner (Dan) | `Admin ▾` | Super admin · divider · `<Partner>` dashboard (admin) | Super admin · divider · `<Partner>` dashboard (admin) |
| partner admin only (Rohan) | `Admin ▾` | `<Partner>` dashboard (admin) | `<Partner>` dashboard (admin) |
| pure super_admin | `Admin ▾` | Super admin | Super admin |
| neither | no entry | — | no admin entries |

## Scope

No schema changes. `getCurrentProfile()` is untouched — `partnerMemberships` is still loaded per-request via the same two-query path. No effect on the slice-1 invite email flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)