### PR TITLE
getRecentFanEdits: add missing deleted_at IS NULL clause to canonical three-clause filter

### DIFF
--- a/src/lib/queries/titles.ts
+++ b/src/lib/queries/titles.ts
@@ -461,6 +461,7 @@ export async function getRecentFanEdits(
     )
     .eq("is_active", true)
     .in("verification_status", PUBLICLY_READABLE_FAN_EDIT_STATUSES)
+    .is("deleted_at", null)
     .eq("titles.is_active", true)
     .order("created_at", { ascending: false })
     .limit(limit);


### PR DESCRIPTION
Close the audit gap from the May-16 leak retrofit.

## Recon outcome

The shared `PUBLICLY_READABLE_FAN_EDIT_STATUSES` constant (`src/lib/fan-edits/status.ts`) is already adopted at **15 canonical-filter sites** — every site the prior recon named plus six more in `p/[slug]/dashboard` and earnings-calc. Zero leaky `'auto_verified'`-only filters remain. The three legitimate `.eq("verification_status", …)` sites are intentional (admin pending-queue counts, parameterized helper).

## The one gap

Three-clause audit (`is_active = true` AND `verification_status IN (…)` AND `deleted_at IS NULL`) found that `getRecentFanEdits` in `src/lib/queries/titles.ts` had only two of the three clauses. Soft-deleted fan_edits could leak into the homepage's "Recent fan edits" carousel (called from `src/app/page.tsx:15`).

## Fix

One-line addition of `.is("deleted_at", null)` between the existing `verification_status` and `titles.is_active` filters, matching the clause ordering used at the other 14 canonical sites.

No constant or schema changes. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)