### PR TITLE
homepage curation slice B: Recent Edits hide+pin + /admin/homepage hub

### DIFF
--- a/src/app/admin/homepage/page.tsx
+++ b/src/app/admin/homepage/page.tsx
@@ -1,0 +1,124 @@
+// /admin/homepage — hub linking the five curators that shape the
+// homepage. Two already exist (Marquee, Featured); one ships in this
+// commit (Recent Edits); two are scoped for follow-ups (All Films,
+// Trending Edits). Disabled placeholder rows show the eventual full
+// shape so an admin scanning the page understands what's coming.
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { requireSuperAdminOr404 } from "@/lib/dal";
+
+export const metadata: Metadata = {
+  title: "Homepage curation · Moonbeem admin",
+  robots: { index: false, follow: false },
+};
+
+type CuratorEntry = {
+  href: string | null;
+  label: string;
+  description: string;
+  status: "live" | "coming-soon";
+};
+
+const ENTRIES: CuratorEntry[] = [
+  {
+    href: "/admin/marquee",
+    label: "Marquee partners",
+    description: "Distribution partner logo strip at the top of the homepage.",
+    status: "live",
+  },
+  {
+    href: "/admin/featured",
+    label: "Featured Films",
+    description: "Editorial-pick title carousel below the partner strip.",
+    status: "live",
+  },
+  {
+    href: "/admin/recent-edits",
+    label: "Recent Edits",
+    description: "Per-fan_edit pin + hide overrides on the recency carousel.",
+    status: "live",
+  },
+  {
+    href: null,
+    label: "All Films",
+    description: "Per-title pin + hide overrides on the comprehensive catalog carousel.",
+    status: "coming-soon",
+  },
+  {
+    href: null,
+    label: "Trending Edits",
+    description:
+      "Per-fan_edit pin + hide overrides layered onto the 24h-delta algorithm.",
+    status: "coming-soon",
+  },
+];
+
+export default async function AdminHomepagePage() {
+  await requireSuperAdminOr404();
+  return (
+    <div className="min-h-screen px-6 py-12 text-moonbeem-ink">
+      <div className="mx-auto flex max-w-3xl flex-col gap-8">
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="font-wordmark text-display-md text-moonbeem-pink m-0">
+            Homepage curation
+          </h1>
+          <Link
+            href="/admin"
+            className="text-body-sm text-moonbeem-ink-muted hover:text-moonbeem-pink"
+          >
+            ← Back to admin
+          </Link>
+        </div>
+        <p className="text-body text-moonbeem-ink-muted m-0">
+          Curate every section of the homepage from one place. Each
+          carousel has its own pin / hide controls — pins float to the
+          top of the section, hidden items drop out of the section only
+          (other carousels still surface them).
+        </p>
+        <ul className="flex flex-col gap-3">
+          {ENTRIES.map((e) =>
+            e.href ? (
+              <li key={e.label}>
+                <Link
+                  href={e.href}
+                  className="flex items-center justify-between gap-4 rounded-2xl border border-white/10 bg-white/[0.02] p-5 transition-colors hover:border-moonbeem-pink"
+                >
+                  <div className="min-w-0">
+                    <div className="text-body font-medium text-moonbeem-ink">
+                      {e.label}
+                    </div>
+                    <p className="m-0 mt-1 text-body-sm text-moonbeem-ink-muted">
+                      {e.description}
+                    </p>
+                  </div>
+                  <span className="shrink-0 text-body-sm text-moonbeem-pink">
+                    Curate →
+                  </span>
+                </Link>
+              </li>
+            ) : (
+              <li
+                key={e.label}
+                aria-disabled="true"
+                className="flex items-center justify-between gap-4 rounded-2xl border border-white/5 bg-white/[0.01] p-5 opacity-60"
+              >
+                <div className="min-w-0">
+                  <div className="text-body font-medium text-moonbeem-ink-muted">
+                    {e.label}
+                  </div>
+                  <p className="m-0 mt-1 text-body-sm text-moonbeem-ink-subtle">
+                    {e.description}
+                  </p>
+                </div>
+                <span className="shrink-0 rounded-full bg-white/5 px-2.5 py-0.5 text-caption text-moonbeem-ink-subtle">
+                  coming soon
+                </span>
+              </li>
+            ),
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -430,6 +430,15 @@ export default async function AdminLanding() {
           </p>
         </div>
 
+        <div className="mt-4">
+          <Link
+            href="/admin/homepage"
+            className="inline-flex items-center gap-2 rounded-md border border-white/10 px-3 py-1.5 text-body-sm text-moonbeem-ink-muted hover:border-moonbeem-pink hover:text-moonbeem-pink"
+          >
+            Curate homepage →
+          </Link>
+        </div>
+
         {/* Quick actions */}
         <div className="mt-10">
           <SectionHeader

--- a/src/app/admin/recent-edits/RecentEditsCurator.tsx
+++ b/src/app/admin/recent-edits/RecentEditsCurator.tsx
@@ -1,0 +1,464 @@
+"use client";
+
+// Client curator for /admin/recent-edits. Mirrors FeaturedCurator's
+// dnd-kit reorder + AddToSearch pattern, plus MarqueeCurator's
+// hide/show two-list shape. Three sections:
+//   1. Pinned — drag to reorder; per-row "Unpin" (X) and "Hide"
+//      buttons.
+//   2. Hidden — per-row "Unhide" button (item returns to candidates).
+//   3. Candidates — top 100 most recent fan_edits not pinned and not
+//      hidden, with a client-side text filter (title / creator handle
+//      / platform). Per-row "Pin" and "Hide" buttons.
+//
+// Every state change posts the FULL pinned + hidden state to
+// /api/admin/fan-edits/recent/reorder. The endpoint is idempotent —
+// it diffs against the current DB state and applies the deltas in
+// one transaction. Optimistic UI; rollback on error.
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  fetchJson,
+  FetchJsonError,
+  RateLimitedError,
+} from "@/lib/fetch-json";
+
+export type RecentCurationItem = {
+  id: string;
+  title_id: string;
+  title_name: string;
+  title_slug: string;
+  title_poster_url: string | null;
+  platform: "tiktok" | "instagram" | "youtube" | "twitter";
+  thumbnail_url: string | null;
+  creator_handle: string;
+  created_at: string;
+  recent_pin_order: number | null;
+  is_hidden_from_recent: boolean;
+};
+
+type Props = {
+  initialPinned: RecentCurationItem[];
+  initialHidden: RecentCurationItem[];
+  initialCandidates: RecentCurationItem[];
+};
+
+function sortByCreatedDesc(a: RecentCurationItem, b: RecentCurationItem) {
+  return b.created_at.localeCompare(a.created_at);
+}
+
+export default function RecentEditsCurator({
+  initialPinned,
+  initialHidden,
+  initialCandidates,
+}: Props) {
+  const router = useRouter();
+  const [pinned, setPinned] = useState<RecentCurationItem[]>(initialPinned);
+  const [hidden, setHidden] = useState<RecentCurationItem[]>(initialHidden);
+  const [candidates, setCandidates] = useState<RecentCurationItem[]>(
+    [...initialCandidates].sort(sortByCreatedDesc),
+  );
+  const [filter, setFilter] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  );
+
+  // Filter applied client-side. Bounded candidate pool (100 rows) so
+  // a naive .filter() is fine; no debounce needed.
+  const filteredCandidates = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return candidates;
+    return candidates.filter((c) => {
+      if (c.title_name.toLowerCase().includes(q)) return true;
+      if (c.creator_handle.toLowerCase().includes(q)) return true;
+      if (c.platform.toLowerCase().includes(q)) return true;
+      return false;
+    });
+  }, [candidates, filter]);
+
+  async function persist(
+    nextPinned: RecentCurationItem[],
+    nextHidden: RecentCurationItem[],
+  ): Promise<boolean> {
+    setSaving(true);
+    setErrorMsg(null);
+    try {
+      await fetchJson("/api/admin/fan-edits/recent/reorder", {
+        method: "POST",
+        body: {
+          pinned: nextPinned.map((p, idx) => ({
+            fan_edit_id: p.id,
+            pin_order: idx + 1,
+          })),
+          hidden: nextHidden.map((h) => h.id),
+        },
+      });
+      router.refresh();
+      return true;
+    } catch (err) {
+      setErrorMsg(
+        err instanceof RateLimitedError || err instanceof FetchJsonError
+          ? err.userMessage
+          : err instanceof Error
+            ? err.message
+            : String(err),
+      );
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = pinned.findIndex((p) => p.id === active.id);
+    const newIndex = pinned.findIndex((p) => p.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+    const prev = pinned;
+    const next = arrayMove(pinned, oldIndex, newIndex);
+    setPinned(next);
+    const ok = await persist(next, hidden);
+    if (!ok) setPinned(prev);
+  }
+
+  async function handlePinCandidate(item: RecentCurationItem) {
+    if (busyId) return;
+    setBusyId(item.id);
+    const prevPinned = pinned;
+    const prevCandidates = candidates;
+    const nextPinned = [...pinned, { ...item, recent_pin_order: pinned.length + 1 }];
+    const nextCandidates = candidates.filter((c) => c.id !== item.id);
+    setPinned(nextPinned);
+    setCandidates(nextCandidates);
+    const ok = await persist(nextPinned, hidden);
+    if (!ok) {
+      setPinned(prevPinned);
+      setCandidates(prevCandidates);
+    }
+    setBusyId(null);
+  }
+
+  async function handleUnpin(item: RecentCurationItem) {
+    if (busyId) return;
+    setBusyId(item.id);
+    const prevPinned = pinned;
+    const prevCandidates = candidates;
+    const nextPinned = pinned.filter((p) => p.id !== item.id);
+    const nextCandidates = [
+      { ...item, recent_pin_order: null },
+      ...candidates,
+    ].sort(sortByCreatedDesc);
+    setPinned(nextPinned);
+    setCandidates(nextCandidates);
+    const ok = await persist(nextPinned, hidden);
+    if (!ok) {
+      setPinned(prevPinned);
+      setCandidates(prevCandidates);
+    }
+    setBusyId(null);
+  }
+
+  async function handleHide(item: RecentCurationItem, from: "pinned" | "candidates") {
+    if (busyId) return;
+    setBusyId(item.id);
+    const prevPinned = pinned;
+    const prevCandidates = candidates;
+    const prevHidden = hidden;
+    const nextPinned =
+      from === "pinned" ? pinned.filter((p) => p.id !== item.id) : pinned;
+    const nextCandidates =
+      from === "candidates"
+        ? candidates.filter((c) => c.id !== item.id)
+        : candidates;
+    const nextHidden = [
+      { ...item, recent_pin_order: null, is_hidden_from_recent: true },
+      ...hidden,
+    ];
+    setPinned(nextPinned);
+    setCandidates(nextCandidates);
+    setHidden(nextHidden);
+    const ok = await persist(nextPinned, nextHidden);
+    if (!ok) {
+      setPinned(prevPinned);
+      setCandidates(prevCandidates);
+      setHidden(prevHidden);
+    }
+    setBusyId(null);
+  }
+
+  async function handleUnhide(item: RecentCurationItem) {
+    if (busyId) return;
+    setBusyId(item.id);
+    const prevHidden = hidden;
+    const prevCandidates = candidates;
+    const nextHidden = hidden.filter((h) => h.id !== item.id);
+    const nextCandidates = [
+      { ...item, is_hidden_from_recent: false },
+      ...candidates,
+    ].sort(sortByCreatedDesc);
+    setHidden(nextHidden);
+    setCandidates(nextCandidates);
+    const ok = await persist(pinned, nextHidden);
+    if (!ok) {
+      setHidden(prevHidden);
+      setCandidates(prevCandidates);
+    }
+    setBusyId(null);
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      {errorMsg && (
+        <p className="text-body-sm text-moonbeem-magenta">{errorMsg}</p>
+      )}
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-display-sm m-0">Pinned ({pinned.length})</h2>
+        {pinned.length === 0 ? (
+          <p className="text-body text-moonbeem-ink-muted">
+            No pinned edits. Drag from the candidate pool below to pin.
+          </p>
+        ) : (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={pinned.map((p) => p.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              <ul
+                className={`flex flex-col gap-2 ${saving ? "opacity-70" : ""}`}
+                aria-busy={saving}
+              >
+                {pinned.map((p, idx) => (
+                  <SortablePinnedRow
+                    key={p.id}
+                    item={p}
+                    position={idx + 1}
+                    onUnpin={() => handleUnpin(p)}
+                    onHide={() => handleHide(p, "pinned")}
+                    isBusy={busyId === p.id}
+                  />
+                ))}
+              </ul>
+            </SortableContext>
+          </DndContext>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-display-sm m-0">Hidden ({hidden.length})</h2>
+        {hidden.length === 0 ? (
+          <p className="text-body text-moonbeem-ink-muted">
+            No hidden edits.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {hidden.map((h) => (
+              <li
+                key={h.id}
+                className="flex items-center gap-3 rounded-md border border-white/10 bg-white/[0.02] px-3 py-2"
+              >
+                <FanEditThumb item={h} />
+                <FanEditMeta item={h} />
+                <button
+                  type="button"
+                  onClick={() => handleUnhide(h)}
+                  disabled={busyId === h.id || saving}
+                  className="rounded-md border border-white/10 px-3 py-1 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-pink hover:text-moonbeem-pink disabled:opacity-40"
+                >
+                  Unhide
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-display-sm m-0">
+          Candidates ({filteredCandidates.length}
+          {filter ? ` / ${candidates.length}` : ""})
+        </h2>
+        <p className="text-caption text-moonbeem-ink-subtle m-0">
+          Top {candidates.length} most-recent fan edits not pinned and
+          not hidden. Filter to find an edit, then pin or hide it.
+        </p>
+        <input
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Filter by title, creator handle, or platform…"
+          className="rounded-md border border-white/10 bg-black/30 px-3 py-2 text-body-sm text-moonbeem-ink placeholder:text-moonbeem-ink-subtle focus:border-moonbeem-pink focus:outline-none"
+        />
+        {filteredCandidates.length === 0 ? (
+          <p className="text-body-sm text-moonbeem-ink-muted">
+            No candidates match.
+          </p>
+        ) : (
+          <ul className="max-h-[600px] flex-col gap-2 overflow-y-auto flex">
+            {filteredCandidates.map((c) => (
+              <li
+                key={c.id}
+                className="flex items-center gap-3 rounded-md border border-white/10 bg-white/[0.02] px-3 py-2"
+              >
+                <FanEditThumb item={c} />
+                <FanEditMeta item={c} />
+                <button
+                  type="button"
+                  onClick={() => handlePinCandidate(c)}
+                  disabled={busyId === c.id || saving}
+                  className="rounded-md border border-white/10 px-3 py-1 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-pink hover:text-moonbeem-pink disabled:opacity-40"
+                >
+                  Pin
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleHide(c, "candidates")}
+                  disabled={busyId === c.id || saving}
+                  aria-label={`Hide ${c.title_name}`}
+                  className="rounded-md border border-white/10 px-3 py-1 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-magenta hover:text-moonbeem-magenta disabled:opacity-40"
+                >
+                  Hide
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function FanEditThumb({ item }: { item: RecentCurationItem }) {
+  if (!item.thumbnail_url) {
+    return (
+      <div
+        className="h-[60px] w-[40px] shrink-0 rounded-sm border border-white/10 bg-white/[0.03]"
+        aria-hidden="true"
+      />
+    );
+  }
+  return (
+    <div className="h-[60px] w-[40px] shrink-0 overflow-hidden rounded-sm bg-white/[0.03]">
+      <Image
+        src={item.thumbnail_url}
+        alt={`${item.title_name} fan edit thumbnail`}
+        width={40}
+        height={60}
+        className="h-full w-full object-cover"
+        unoptimized
+      />
+    </div>
+  );
+}
+
+function FanEditMeta({ item }: { item: RecentCurationItem }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="truncate text-body-sm text-moonbeem-ink">
+        {item.title_name}
+      </div>
+      <div className="truncate font-mono text-caption text-moonbeem-ink-subtle">
+        @{item.creator_handle} · {item.platform}
+      </div>
+    </div>
+  );
+}
+
+function SortablePinnedRow({
+  item,
+  position,
+  onUnpin,
+  onHide,
+  isBusy,
+}: {
+  item: RecentCurationItem;
+  position: number;
+  onUnpin: () => void;
+  onHide: () => void;
+  isBusy: boolean;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 20 : undefined,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-3 rounded-md border bg-white/[0.02] px-3 py-2 ${
+        isDragging
+          ? "border-moonbeem-pink shadow-[0_8px_24px_rgba(245,197,225,0.25)]"
+          : "border-white/10"
+      }`}
+    >
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        aria-label={`Drag ${item.title_name} to reorder`}
+        className="cursor-grab touch-none px-1 text-moonbeem-ink-subtle hover:text-moonbeem-ink"
+      >
+        ⋮⋮
+      </button>
+      <span className="w-6 shrink-0 text-right font-mono text-body-sm text-moonbeem-ink-subtle tabular-nums">
+        {position}
+      </span>
+      <FanEditThumb item={item} />
+      <FanEditMeta item={item} />
+      <button
+        type="button"
+        onClick={onHide}
+        disabled={isBusy}
+        aria-label={`Hide ${item.title_name}`}
+        className="rounded-md border border-white/10 px-2.5 py-1 text-caption text-moonbeem-ink-muted transition-colors hover:border-moonbeem-magenta hover:text-moonbeem-magenta disabled:opacity-40"
+      >
+        Hide
+      </button>
+      <button
+        type="button"
+        onClick={onUnpin}
+        disabled={isBusy}
+        aria-label={`Unpin ${item.title_name}`}
+        className="h-7 w-7 shrink-0 rounded-full border border-white/10 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-magenta hover:text-moonbeem-magenta disabled:opacity-40"
+      >
+        ×
+      </button>
+    </li>
+  );
+}

--- a/src/app/admin/recent-edits/page.tsx
+++ b/src/app/admin/recent-edits/page.tsx
@@ -1,0 +1,187 @@
+// /admin/recent-edits — super-admin curation of the homepage Recent
+// Edits carousel. Mirrors /admin/featured + /admin/marquee:
+//   1. Reorder pinned via drag-and-drop (persists recent_pin_order).
+//   2. Hide a fan_edit from the carousel (persists
+//      is_hidden_from_recent = true) without affecting any other
+//      surface.
+//   3. Pin a candidate (recent_pin_order = next-available) from the
+//      filterable candidate pool.
+//   4. Unpin / Unhide reverse those operations.
+//
+// The carousel on the homepage reads getRecentFanEdits(), now
+// ordered by recent_pin_order ASC NULLS LAST, then created_at DESC,
+// filtered to is_hidden_from_recent=false. Mutation calls
+// revalidatePath('/') so the carousel reflects changes on the next
+// visit.
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { requireSuperAdminOr404 } from "@/lib/dal";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import { PUBLICLY_READABLE_FAN_EDIT_STATUSES } from "@/lib/fan-edits/status";
+import RecentEditsCurator, {
+  type RecentCurationItem,
+} from "./RecentEditsCurator";
+
+export const metadata: Metadata = {
+  title: "Recent Edits curation · Moonbeem admin",
+  robots: { index: false, follow: false },
+};
+
+type FanEditRow = {
+  id: string;
+  title_id: string;
+  platform: "tiktok" | "instagram" | "youtube" | "twitter";
+  embed_url: string;
+  thumbnail_url: string | null;
+  creator_handle_displayed: string | null;
+  creator_id: string | null;
+  created_at: string;
+  recent_pin_order: number | null;
+  is_hidden_from_recent: boolean;
+  titles: {
+    slug: string;
+    title: string;
+    poster_url: string | null;
+    is_active: boolean;
+  } | null;
+};
+
+// Bounded candidate pool — the unpinned-unhidden set, top 100 by
+// created_at DESC. Plenty of headroom over today's ~290 active fan_edits;
+// admin filters in-memory client-side.
+const CANDIDATE_POOL_LIMIT = 100;
+
+const FAN_EDIT_SELECT =
+  "id, title_id, platform, embed_url, thumbnail_url, creator_handle_displayed, creator_id, created_at, recent_pin_order, is_hidden_from_recent, titles!inner(slug, title, poster_url, is_active)";
+
+function mapRow(
+  r: FanEditRow,
+  creatorHandleById: Map<string, string>,
+): RecentCurationItem | null {
+  if (!r.titles) return null;
+  const moonbeemHandle = r.creator_id
+    ? (creatorHandleById.get(r.creator_id) ?? null)
+    : null;
+  return {
+    id: r.id,
+    title_id: r.title_id,
+    title_name: r.titles.title,
+    title_slug: r.titles.slug,
+    title_poster_url: r.titles.poster_url,
+    platform: r.platform,
+    thumbnail_url: r.thumbnail_url,
+    creator_handle:
+      moonbeemHandle ?? r.creator_handle_displayed ?? "anon",
+    created_at: r.created_at,
+    recent_pin_order: r.recent_pin_order,
+    is_hidden_from_recent: r.is_hidden_from_recent,
+  };
+}
+
+export default async function AdminRecentEditsPage() {
+  await requireSuperAdminOr404();
+  const supabase = createServiceRoleClient();
+
+  // Single-shot fetch of all curator-relevant fan_edits. Canonical
+  // three-clause gate (is_active + verification_status + deleted_at);
+  // titles must also be active. We sort client-side into pinned /
+  // hidden / candidate buckets so the admin sees ONLY rows the
+  // homepage would consider — no curating something the gate would
+  // drop anyway.
+  const { data: pinnedRaw } = await supabase
+    .from("fan_edits")
+    .select(FAN_EDIT_SELECT)
+    .eq("is_active", true)
+    .in("verification_status", PUBLICLY_READABLE_FAN_EDIT_STATUSES)
+    .is("deleted_at", null)
+    .eq("titles.is_active", true)
+    .not("recent_pin_order", "is", null)
+    .order("recent_pin_order", { ascending: true });
+
+  const { data: hiddenRaw } = await supabase
+    .from("fan_edits")
+    .select(FAN_EDIT_SELECT)
+    .eq("is_active", true)
+    .in("verification_status", PUBLICLY_READABLE_FAN_EDIT_STATUSES)
+    .is("deleted_at", null)
+    .eq("titles.is_active", true)
+    .eq("is_hidden_from_recent", true)
+    .order("created_at", { ascending: false });
+
+  const { data: candidatesRaw } = await supabase
+    .from("fan_edits")
+    .select(FAN_EDIT_SELECT)
+    .eq("is_active", true)
+    .in("verification_status", PUBLICLY_READABLE_FAN_EDIT_STATUSES)
+    .is("deleted_at", null)
+    .eq("titles.is_active", true)
+    .is("recent_pin_order", null)
+    .eq("is_hidden_from_recent", false)
+    .order("created_at", { ascending: false })
+    .limit(CANDIDATE_POOL_LIMIT);
+
+  const pinnedRows = (pinnedRaw ?? []) as unknown as FanEditRow[];
+  const hiddenRows = (hiddenRaw ?? []) as unknown as FanEditRow[];
+  const candidateRows = (candidatesRaw ?? []) as unknown as FanEditRow[];
+
+  // One creator-handle lookup across all three sets.
+  const creatorIds = Array.from(
+    new Set(
+      [...pinnedRows, ...hiddenRows, ...candidateRows]
+        .map((r) => r.creator_id)
+        .filter((id): id is string => !!id),
+    ),
+  );
+  const creatorHandleById = new Map<string, string>();
+  if (creatorIds.length > 0) {
+    const { data: creators } = await supabase
+      .from("public_creators")
+      .select("id, moonbeem_handle")
+      .in("id", creatorIds);
+    for (const c of (creators ?? []) as Array<{
+      id: string;
+      moonbeem_handle: string;
+    }>) {
+      creatorHandleById.set(c.id, c.moonbeem_handle);
+    }
+  }
+
+  const pinned = pinnedRows
+    .map((r) => mapRow(r, creatorHandleById))
+    .filter((x): x is RecentCurationItem => x !== null);
+  const hidden = hiddenRows
+    .map((r) => mapRow(r, creatorHandleById))
+    .filter((x): x is RecentCurationItem => x !== null);
+  const candidates = candidateRows
+    .map((r) => mapRow(r, creatorHandleById))
+    .filter((x): x is RecentCurationItem => x !== null);
+
+  return (
+    <div className="min-h-screen px-6 py-12 text-moonbeem-ink">
+      <div className="mx-auto flex max-w-3xl flex-col gap-8">
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="font-wordmark text-display-md text-moonbeem-pink m-0">
+            Recent Edits curation
+          </h1>
+          <Link
+            href="/admin/homepage"
+            className="text-body-sm text-moonbeem-ink-muted hover:text-moonbeem-pink"
+          >
+            ← Back to homepage curation
+          </Link>
+        </div>
+        <p className="text-body text-moonbeem-ink-muted m-0">
+          Curate the homepage Recent Edits carousel. Drag pinned rows to
+          reorder; X to unpin; eye icon to hide. Search the candidate
+          pool below to find more edits to pin or hide.
+        </p>
+        <RecentEditsCurator
+          initialPinned={pinned}
+          initialHidden={hidden}
+          initialCandidates={candidates}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/fan-edits/recent/reorder/route.ts
+++ b/src/app/api/admin/fan-edits/recent/reorder/route.ts
@@ -1,0 +1,272 @@
+// POST /api/admin/fan-edits/recent/reorder — super-admin curation of
+// the homepage Recent Edits carousel. One endpoint handles every
+// state mutation (pin, unpin, reorder, hide, unhide); the body is a
+// complete declaration of the new pinned + hidden state.
+//
+// Body shape:
+//   {
+//     pinned: [{ fan_edit_id: uuid, pin_order: 1..N }, …],
+//     hidden: [uuid, …]
+//   }
+//
+// Semantics:
+//   1. Every fan_edit_id in `pinned` becomes pinned with the given
+//      recent_pin_order. Any fan_edit currently pinned but absent from
+//      the new `pinned` array is unpinned (recent_pin_order = NULL).
+//   2. Every fan_edit_id in `hidden` becomes hidden
+//      (is_hidden_from_recent = TRUE). Any fan_edit currently hidden
+//      but absent from the new `hidden` array is unhidden.
+//   3. All referenced fan_edits must exist AND pass the canonical
+//      three-clause gate (is_active + verification_status IN
+//      PUBLICLY_READABLE_FAN_EDIT_STATUSES + deleted_at IS NULL).
+//      Caller is responsible for not declaring an invalid candidate;
+//      this gate is the backstop.
+//
+// Reorder follows the same two-phase shuffle pattern as
+// /api/admin/titles/featured/reorder — bump pinned rows to a high
+// temporary range, then settle them at the requested positions. No
+// UNIQUE on recent_pin_order today, but the pattern matches and
+// future-proofs.
+//
+// revalidatePath('/') after the writes so the homepage carousel
+// reflects the new state on the next visit.
+
+import { NextResponse, type NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { requireSuperAdmin } from "@/lib/dal";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import { enforce } from "@/lib/ratelimit";
+import { PUBLICLY_READABLE_FAN_EDIT_STATUSES } from "@/lib/fan-edits/status";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const MAX_ENTRIES = 100;
+const TEMP_OFFSET = 10_000;
+
+type PinEntry = { fan_edit_id: string; pin_order: number };
+
+export async function POST(request: NextRequest) {
+  const session = await requireSuperAdmin();
+  const limit = await enforce(
+    "admin",
+    session.userId,
+    "admin/fan-edits/recent/reorder",
+  );
+  if (!limit.ok) return limit.response;
+
+  let body: { pinned?: PinEntry[]; hidden?: string[] };
+  try {
+    body = (await request.json()) as {
+      pinned?: PinEntry[];
+      hidden?: string[];
+    };
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const pinnedIn = Array.isArray(body.pinned) ? body.pinned : [];
+  const hiddenIn = Array.isArray(body.hidden) ? body.hidden : [];
+
+  if (pinnedIn.length > MAX_ENTRIES) {
+    return NextResponse.json(
+      { error: "too_many_pinned" },
+      { status: 400 },
+    );
+  }
+  if (hiddenIn.length > MAX_ENTRIES) {
+    return NextResponse.json(
+      { error: "too_many_hidden" },
+      { status: 400 },
+    );
+  }
+
+  // Validate pinned entries — uuid shape, position bounds, no dup ids,
+  // no dup positions.
+  const pinnedSeenIds = new Set<string>();
+  const pinnedSeenPos = new Set<number>();
+  for (const e of pinnedIn) {
+    const fid = (e?.fan_edit_id ?? "").trim();
+    const pos = Number(e?.pin_order);
+    if (!UUID_RE.test(fid)) {
+      return NextResponse.json(
+        { error: "invalid_fan_edit_id" },
+        { status: 400 },
+      );
+    }
+    if (!Number.isInteger(pos) || pos < 1 || pos > MAX_ENTRIES) {
+      return NextResponse.json(
+        { error: "invalid_pin_order" },
+        { status: 400 },
+      );
+    }
+    if (pinnedSeenIds.has(fid)) {
+      return NextResponse.json(
+        { error: "duplicate_fan_edit_id" },
+        { status: 400 },
+      );
+    }
+    if (pinnedSeenPos.has(pos)) {
+      return NextResponse.json(
+        { error: "duplicate_pin_order" },
+        { status: 400 },
+      );
+    }
+    pinnedSeenIds.add(fid);
+    pinnedSeenPos.add(pos);
+  }
+
+  // Validate hidden uuids.
+  const hiddenSeen = new Set<string>();
+  for (const id of hiddenIn) {
+    const fid = (id ?? "").trim();
+    if (!UUID_RE.test(fid)) {
+      return NextResponse.json(
+        { error: "invalid_fan_edit_id" },
+        { status: 400 },
+      );
+    }
+    if (hiddenSeen.has(fid)) {
+      return NextResponse.json(
+        { error: "duplicate_hidden_id" },
+        { status: 400 },
+      );
+    }
+    hiddenSeen.add(fid);
+  }
+
+  // A fan_edit can't be both pinned and hidden at the same time. If
+  // the caller declares it in both, that's an inconsistent state —
+  // reject loudly rather than apply something nondeterministic.
+  for (const id of pinnedSeenIds) {
+    if (hiddenSeen.has(id)) {
+      return NextResponse.json(
+        { error: "fan_edit_both_pinned_and_hidden", fan_edit_id: id },
+        { status: 400 },
+      );
+    }
+  }
+
+  const supabase = createServiceRoleClient();
+
+  // Canonical three-clause gate on every referenced fan_edit. Caller
+  // SHOULD never declare an invalid candidate (the curator's data
+  // loader filters by the gate), but this is the server backstop.
+  const referencedIds = [...pinnedSeenIds, ...hiddenSeen];
+  if (referencedIds.length > 0) {
+    const { data: valid, error: readErr } = await supabase
+      .from("fan_edits")
+      .select("id")
+      .in("id", referencedIds)
+      .eq("is_active", true)
+      .in("verification_status", PUBLICLY_READABLE_FAN_EDIT_STATUSES)
+      .is("deleted_at", null);
+    if (readErr) {
+      return NextResponse.json({ error: readErr.message }, { status: 500 });
+    }
+    const validSet = new Set((valid ?? []).map((r) => r.id as string));
+    for (const id of referencedIds) {
+      if (!validSet.has(id)) {
+        return NextResponse.json(
+          { error: "fan_edit_not_curatable", fan_edit_id: id },
+          { status: 400 },
+        );
+      }
+    }
+  }
+
+  // Current state lookup so we can diff and apply only the changes.
+  const [currentPinnedRes, currentHiddenRes] = await Promise.all([
+    supabase
+      .from("fan_edits")
+      .select("id")
+      .not("recent_pin_order", "is", null),
+    supabase
+      .from("fan_edits")
+      .select("id")
+      .eq("is_hidden_from_recent", true),
+  ]);
+  if (currentPinnedRes.error) {
+    return NextResponse.json(
+      { error: currentPinnedRes.error.message },
+      { status: 500 },
+    );
+  }
+  if (currentHiddenRes.error) {
+    return NextResponse.json(
+      { error: currentHiddenRes.error.message },
+      { status: 500 },
+    );
+  }
+  const currentPinned = new Set(
+    (currentPinnedRes.data ?? []).map((r) => r.id as string),
+  );
+  const currentHidden = new Set(
+    (currentHiddenRes.data ?? []).map((r) => r.id as string),
+  );
+
+  const newPinned = pinnedSeenIds;
+  const newHidden = hiddenSeen;
+
+  // 1. Unpin anyone currently pinned but absent from the new set.
+  const toUnpin = [...currentPinned].filter((id) => !newPinned.has(id));
+  if (toUnpin.length > 0) {
+    const { error } = await supabase
+      .from("fan_edits")
+      .update({ recent_pin_order: null })
+      .in("id", toUnpin);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  }
+
+  // 2. Unhide anyone currently hidden but absent from the new set.
+  const toUnhide = [...currentHidden].filter((id) => !newHidden.has(id));
+  if (toUnhide.length > 0) {
+    const { error } = await supabase
+      .from("fan_edits")
+      .update({ is_hidden_from_recent: false })
+      .in("id", toUnhide);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  }
+
+  // 3. Hide every id in newHidden (idempotent on already-hidden rows).
+  if (newHidden.size > 0) {
+    const { error } = await supabase
+      .from("fan_edits")
+      .update({ is_hidden_from_recent: true, recent_pin_order: null })
+      .in("id", [...newHidden]);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  }
+
+  // 4. Two-phase pin write — bump to TEMP_OFFSET range, then settle.
+  //    Mirrors /api/admin/titles/featured/reorder pattern; collision-
+  //    free even if a UNIQUE is added to recent_pin_order later.
+  if (pinnedIn.length > 0) {
+    for (let i = 0; i < pinnedIn.length; i++) {
+      const { error } = await supabase
+        .from("fan_edits")
+        .update({ recent_pin_order: TEMP_OFFSET + i, is_hidden_from_recent: false })
+        .eq("id", pinnedIn[i].fan_edit_id);
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+    }
+    for (const e of pinnedIn) {
+      const { error } = await supabase
+        .from("fan_edits")
+        .update({ recent_pin_order: e.pin_order })
+        .eq("id", e.fan_edit_id);
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+    }
+  }
+
+  revalidatePath("/");
+  return NextResponse.json({ success: true });
+}

--- a/src/lib/queries/titles.ts
+++ b/src/lib/queries/titles.ts
@@ -462,7 +462,13 @@ export async function getRecentFanEdits(
     .eq("is_active", true)
     .in("verification_status", PUBLICLY_READABLE_FAN_EDIT_STATUSES)
     .is("deleted_at", null)
+    .eq("is_hidden_from_recent", false)
     .eq("titles.is_active", true)
+    // Pinned rows (recent_pin_order NOT NULL, ASC NULLS LAST) take
+    // the top slots; the rest fill from created_at DESC. The 12-row
+    // LIMIT applies after the combined sort, so a pinned set of N
+    // displaces the N oldest items that would otherwise have shown.
+    .order("recent_pin_order", { ascending: true, nullsFirst: false })
     .order("created_at", { ascending: false })
     .limit(limit);
   if (error || !data) return [];

--- a/supabase/migrations/20260526000001_fan_edits_recent_curation.sql
+++ b/supabase/migrations/20260526000001_fan_edits_recent_curation.sql
@@ -1,0 +1,34 @@
+-- Add per-fan_edit columns for super-admin curation of the homepage
+-- Recent Edits carousel. Today the carousel uses created_at DESC; this
+-- migration leaves all rows with no curation overrides on rollout
+-- (recent_pin_order NULL on every row, is_hidden_from_recent FALSE).
+-- The /admin/recent-edits page (shipping in the same commit) is the
+-- first surface that mutates these columns.
+--
+-- Defaults & invariants:
+--   - recent_pin_order INTEGER NULL — pinned position; NULL = not
+--     pinned; smaller numbers = higher pin position. The homepage
+--     query renders pinned rows first (ORDER BY recent_pin_order ASC
+--     NULLS LAST), then the remaining slots fill from created_at DESC.
+--   - is_hidden_from_recent BOOLEAN NOT NULL DEFAULT FALSE — excludes
+--     a fan_edit from the Recent Edits carousel ONLY. Per-carousel
+--     hide, not a global hide: All Films / Featured / Trending each
+--     get their own hide flag in future slices so the same edit can
+--     be hidden from one surface without being hidden from another.
+--   - No index. The homepage selects a top-12 set; the pinned subset
+--     stays tiny in practice (1-5 rows). If pinned-set size grows past
+--     ~50, a partial index on (recent_pin_order) WHERE recent_pin_order
+--     IS NOT NULL would speed the ORDER BY; not warranted yet.
+--   - Per-carousel naming follows the established Featured precedent
+--     (titles.featured_order). The "recent_" prefix leaves room for
+--     parallel allfilms_pin_order and trending_pin_order in Slices A
+--     and C without column-name collisions.
+--
+-- Mirrors 20260512000007 (titles_featured_order) but on fan_edits and
+-- with both a pin-order column AND a hide flag — Recent supports
+-- "hide-but-leave-on-the-platform"; Featured was binary (is_featured
+-- on/off) and didn't need a separate hide.
+
+alter table public.fan_edits
+  add column if not exists recent_pin_order integer,
+  add column if not exists is_hidden_from_recent boolean not null default false;


### PR DESCRIPTION
First slice of homepage carousel curation (recon → spec → build → ship). Adds super-admin pin + hide control over the homepage Recent Edits carousel, plus a hub page that surfaces every homepage curator from one place.

## What ships

**Migration `20260526000001_fan_edits_recent_curation.sql`** (already applied to prod):
- `fan_edits.recent_pin_order` (INT NULL) — pin position; smaller = higher; NULL = not pinned
- `fan_edits.is_hidden_from_recent` (BOOL NOT NULL DEFAULT FALSE) — per-carousel hide

Schema mirrors the Featured/Marquee precedent (per-entity columns on the entity table). No index; pinned subset stays tiny.

**`getRecentFanEdits` update:** adds `is_hidden_from_recent = false` filter; ORDER BY `recent_pin_order ASC NULLS LAST, created_at DESC`. Composes with the canonical three-clause gate.

**`/admin/recent-edits` curator** (new page + client component): three sections — Pinned (drag-reorderable via dnd-kit), Hidden, Candidates (top-100 pool with client-side filter). Every state change posts the full pinned+hidden state.

**`/api/admin/fan-edits/recent/reorder` API** (new): full-state-declaration semantics. Validates the canonical three-clause gate as backstop. Diffs vs current DB state; applies deltas; two-phase pin write mirrors `/api/admin/titles/featured/reorder`'s pattern. `revalidatePath('/')` on success.

**`/admin/homepage` hub** (new): lists Marquee, Featured, Recent Edits (live) + All Films, Trending Edits (coming-soon placeholders for slices A and C).

**`/admin` nav:** new `Curate homepage →` button under the page header.

## Scope

7 files (+1096 lines). `npm run build` clean. No changes to `/admin/featured`, `/admin/marquee`, or any partner-side surface. Per-carousel hide flag means the same fan_edit can be hidden from Recent without affecting other surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)