### PR TITLE
homepage curation slice A: All Films hide+pin

### DIFF
--- a/src/app/admin/all-films/AllFilmsCurator.tsx
+++ b/src/app/admin/all-films/AllFilmsCurator.tsx
@@ -1,0 +1,467 @@
+"use client";
+
+// Client curator for /admin/all-films. Mirrors RecentEditsCurator's
+// three-section shape but on titles — Pinned (drag-orderable),
+// Hidden, Candidates (filterable pool). Every state change posts
+// the full pinned+hidden state to /api/admin/titles/allfilms/reorder,
+// which diffs against current DB state and applies deltas in a
+// single transaction. Optimistic UI; rollback on error.
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  fetchJson,
+  FetchJsonError,
+  RateLimitedError,
+} from "@/lib/fetch-json";
+
+export type AllFilmsCurationItem = {
+  id: string;
+  slug: string;
+  title: string;
+  year: number | null;
+  poster_url: string | null;
+  created_at: string;
+  allfilms_pin_order: number | null;
+  is_hidden_from_all_films: boolean;
+};
+
+type Props = {
+  initialPinned: AllFilmsCurationItem[];
+  initialHidden: AllFilmsCurationItem[];
+  initialCandidates: AllFilmsCurationItem[];
+};
+
+function sortByCreatedDesc(
+  a: AllFilmsCurationItem,
+  b: AllFilmsCurationItem,
+) {
+  return b.created_at.localeCompare(a.created_at);
+}
+
+export default function AllFilmsCurator({
+  initialPinned,
+  initialHidden,
+  initialCandidates,
+}: Props) {
+  const router = useRouter();
+  const [pinned, setPinned] =
+    useState<AllFilmsCurationItem[]>(initialPinned);
+  const [hidden, setHidden] =
+    useState<AllFilmsCurationItem[]>(initialHidden);
+  const [candidates, setCandidates] = useState<AllFilmsCurationItem[]>(
+    [...initialCandidates].sort(sortByCreatedDesc),
+  );
+  const [filter, setFilter] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  );
+
+  const filteredCandidates = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return candidates;
+    return candidates.filter((c) => {
+      if (c.title.toLowerCase().includes(q)) return true;
+      if (c.slug.toLowerCase().includes(q)) return true;
+      if (c.year && String(c.year).includes(q)) return true;
+      return false;
+    });
+  }, [candidates, filter]);
+
+  async function persist(
+    nextPinned: AllFilmsCurationItem[],
+    nextHidden: AllFilmsCurationItem[],
+  ): Promise<boolean> {
+    setSaving(true);
+    setErrorMsg(null);
+    try {
+      await fetchJson("/api/admin/titles/allfilms/reorder", {
+        method: "POST",
+        body: {
+          pinned: nextPinned.map((p, idx) => ({
+            title_id: p.id,
+            pin_order: idx + 1,
+          })),
+          hidden: nextHidden.map((h) => h.id),
+        },
+      });
+      router.refresh();
+      return true;
+    } catch (err) {
+      setErrorMsg(
+        err instanceof RateLimitedError || err instanceof FetchJsonError
+          ? err.userMessage
+          : err instanceof Error
+            ? err.message
+            : String(err),
+      );
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = pinned.findIndex((p) => p.id === active.id);
+    const newIndex = pinned.findIndex((p) => p.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+    const prev = pinned;
+    const next = arrayMove(pinned, oldIndex, newIndex);
+    setPinned(next);
+    const ok = await persist(next, hidden);
+    if (!ok) setPinned(prev);
+  }
+
+  async function handlePinCandidate(item: AllFilmsCurationItem) {
+    if (busyId) return;
+    setBusyId(item.id);
+    const prevPinned = pinned;
+    const prevCandidates = candidates;
+    const nextPinned = [
+      ...pinned,
+      { ...item, allfilms_pin_order: pinned.length + 1 },
+    ];
+    const nextCandidates = candidates.filter((c) => c.id !== item.id);
+    setPinned(nextPinned);
+    setCandidates(nextCandidates);
+    const ok = await persist(nextPinned, hidden);
+    if (!ok) {
+      setPinned(prevPinned);
+      setCandidates(prevCandidates);
+    }
+    setBusyId(null);
+  }
+
+  async function handleUnpin(item: AllFilmsCurationItem) {
+    if (busyId) return;
+    setBusyId(item.id);
+    const prevPinned = pinned;
+    const prevCandidates = candidates;
+    const nextPinned = pinned.filter((p) => p.id !== item.id);
+    const nextCandidates = [
+      { ...item, allfilms_pin_order: null },
+      ...candidates,
+    ].sort(sortByCreatedDesc);
+    setPinned(nextPinned);
+    setCandidates(nextCandidates);
+    const ok = await persist(nextPinned, hidden);
+    if (!ok) {
+      setPinned(prevPinned);
+      setCandidates(prevCandidates);
+    }
+    setBusyId(null);
+  }
+
+  async function handleHide(
+    item: AllFilmsCurationItem,
+    from: "pinned" | "candidates",
+  ) {
+    if (busyId) return;
+    setBusyId(item.id);
+    const prevPinned = pinned;
+    const prevCandidates = candidates;
+    const prevHidden = hidden;
+    const nextPinned =
+      from === "pinned" ? pinned.filter((p) => p.id !== item.id) : pinned;
+    const nextCandidates =
+      from === "candidates"
+        ? candidates.filter((c) => c.id !== item.id)
+        : candidates;
+    const nextHidden = [
+      {
+        ...item,
+        allfilms_pin_order: null,
+        is_hidden_from_all_films: true,
+      },
+      ...hidden,
+    ];
+    setPinned(nextPinned);
+    setCandidates(nextCandidates);
+    setHidden(nextHidden);
+    const ok = await persist(nextPinned, nextHidden);
+    if (!ok) {
+      setPinned(prevPinned);
+      setCandidates(prevCandidates);
+      setHidden(prevHidden);
+    }
+    setBusyId(null);
+  }
+
+  async function handleUnhide(item: AllFilmsCurationItem) {
+    if (busyId) return;
+    setBusyId(item.id);
+    const prevHidden = hidden;
+    const prevCandidates = candidates;
+    const nextHidden = hidden.filter((h) => h.id !== item.id);
+    const nextCandidates = [
+      { ...item, is_hidden_from_all_films: false },
+      ...candidates,
+    ].sort(sortByCreatedDesc);
+    setHidden(nextHidden);
+    setCandidates(nextCandidates);
+    const ok = await persist(pinned, nextHidden);
+    if (!ok) {
+      setHidden(prevHidden);
+      setCandidates(prevCandidates);
+    }
+    setBusyId(null);
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      {errorMsg && (
+        <p className="text-body-sm text-moonbeem-magenta">{errorMsg}</p>
+      )}
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-display-sm m-0">Pinned ({pinned.length})</h2>
+        {pinned.length === 0 ? (
+          <p className="text-body text-moonbeem-ink-muted">
+            No pinned films. Pin a film from the candidate pool below.
+          </p>
+        ) : (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={pinned.map((p) => p.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              <ul
+                className={`flex flex-col gap-2 ${saving ? "opacity-70" : ""}`}
+                aria-busy={saving}
+              >
+                {pinned.map((p, idx) => (
+                  <SortablePinnedRow
+                    key={p.id}
+                    item={p}
+                    position={idx + 1}
+                    onUnpin={() => handleUnpin(p)}
+                    onHide={() => handleHide(p, "pinned")}
+                    isBusy={busyId === p.id}
+                  />
+                ))}
+              </ul>
+            </SortableContext>
+          </DndContext>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-display-sm m-0">Hidden ({hidden.length})</h2>
+        {hidden.length === 0 ? (
+          <p className="text-body text-moonbeem-ink-muted">No hidden films.</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {hidden.map((h) => (
+              <li
+                key={h.id}
+                className="flex items-center gap-3 rounded-md border border-white/10 bg-white/[0.02] px-3 py-2"
+              >
+                <PosterThumb url={h.poster_url} alt={`${h.title} poster`} />
+                <TitleMeta item={h} />
+                <button
+                  type="button"
+                  onClick={() => handleUnhide(h)}
+                  disabled={busyId === h.id || saving}
+                  className="rounded-md border border-white/10 px-3 py-1 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-pink hover:text-moonbeem-pink disabled:opacity-40"
+                >
+                  Unhide
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-display-sm m-0">
+          Candidates ({filteredCandidates.length}
+          {filter ? ` / ${candidates.length}` : ""})
+        </h2>
+        <p className="text-caption text-moonbeem-ink-subtle m-0">
+          Top {candidates.length} most-recent films not pinned and not
+          hidden. Filter to find a film, then pin or hide it.
+        </p>
+        <input
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Filter by title, slug, or year…"
+          className="rounded-md border border-white/10 bg-black/30 px-3 py-2 text-body-sm text-moonbeem-ink placeholder:text-moonbeem-ink-subtle focus:border-moonbeem-pink focus:outline-none"
+        />
+        {filteredCandidates.length === 0 ? (
+          <p className="text-body-sm text-moonbeem-ink-muted">
+            No candidates match.
+          </p>
+        ) : (
+          <ul className="max-h-[600px] flex-col gap-2 overflow-y-auto flex">
+            {filteredCandidates.map((c) => (
+              <li
+                key={c.id}
+                className="flex items-center gap-3 rounded-md border border-white/10 bg-white/[0.02] px-3 py-2"
+              >
+                <PosterThumb url={c.poster_url} alt={`${c.title} poster`} />
+                <TitleMeta item={c} />
+                <button
+                  type="button"
+                  onClick={() => handlePinCandidate(c)}
+                  disabled={busyId === c.id || saving}
+                  className="rounded-md border border-white/10 px-3 py-1 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-pink hover:text-moonbeem-pink disabled:opacity-40"
+                >
+                  Pin
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleHide(c, "candidates")}
+                  disabled={busyId === c.id || saving}
+                  aria-label={`Hide ${c.title}`}
+                  className="rounded-md border border-white/10 px-3 py-1 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-magenta hover:text-moonbeem-magenta disabled:opacity-40"
+                >
+                  Hide
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function PosterThumb({ url, alt }: { url: string | null; alt: string }) {
+  if (!url) {
+    return (
+      <div
+        className="h-[60px] w-[40px] shrink-0 rounded-sm border border-white/10 bg-white/[0.03]"
+        aria-hidden="true"
+      />
+    );
+  }
+  return (
+    <div className="h-[60px] w-[40px] shrink-0 overflow-hidden rounded-sm bg-white/[0.03]">
+      <Image
+        src={url}
+        alt={alt}
+        width={40}
+        height={60}
+        className="h-full w-full object-cover"
+        unoptimized
+      />
+    </div>
+  );
+}
+
+function TitleMeta({ item }: { item: AllFilmsCurationItem }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="truncate text-body-sm text-moonbeem-ink">
+        {item.title}
+        {item.year && (
+          <span className="ml-2 text-moonbeem-ink-subtle">({item.year})</span>
+        )}
+      </div>
+      <div className="truncate font-mono text-caption text-moonbeem-ink-subtle">
+        /t/{item.slug}
+      </div>
+    </div>
+  );
+}
+
+function SortablePinnedRow({
+  item,
+  position,
+  onUnpin,
+  onHide,
+  isBusy,
+}: {
+  item: AllFilmsCurationItem;
+  position: number;
+  onUnpin: () => void;
+  onHide: () => void;
+  isBusy: boolean;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 20 : undefined,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-3 rounded-md border bg-white/[0.02] px-3 py-2 ${
+        isDragging
+          ? "border-moonbeem-pink shadow-[0_8px_24px_rgba(245,197,225,0.25)]"
+          : "border-white/10"
+      }`}
+    >
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        aria-label={`Drag ${item.title} to reorder`}
+        className="cursor-grab touch-none px-1 text-moonbeem-ink-subtle hover:text-moonbeem-ink"
+      >
+        ⋮⋮
+      </button>
+      <span className="w-6 shrink-0 text-right font-mono text-body-sm text-moonbeem-ink-subtle tabular-nums">
+        {position}
+      </span>
+      <PosterThumb url={item.poster_url} alt={`${item.title} poster`} />
+      <TitleMeta item={item} />
+      <button
+        type="button"
+        onClick={onHide}
+        disabled={isBusy}
+        aria-label={`Hide ${item.title}`}
+        className="rounded-md border border-white/10 px-2.5 py-1 text-caption text-moonbeem-ink-muted transition-colors hover:border-moonbeem-magenta hover:text-moonbeem-magenta disabled:opacity-40"
+      >
+        Hide
+      </button>
+      <button
+        type="button"
+        onClick={onUnpin}
+        disabled={isBusy}
+        aria-label={`Unpin ${item.title}`}
+        className="h-7 w-7 shrink-0 rounded-full border border-white/10 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-magenta hover:text-moonbeem-magenta disabled:opacity-40"
+      >
+        ×
+      </button>
+    </li>
+  );
+}

--- a/src/app/admin/all-films/page.tsx
+++ b/src/app/admin/all-films/page.tsx
@@ -1,0 +1,128 @@
+// /admin/all-films — super-admin curation of the homepage All Films
+// carousel. Mirrors /admin/recent-edits's three-section shape
+// (Pinned / Hidden / Candidates) but on titles. All Films is an
+// "everything" carousel (no LIMIT on the homepage query), so pinning
+// promotes a small set to the top and hiding removes from the
+// section only — Featured / partner pages still surface the title.
+//
+// The carousel on the homepage reads getAllFilms(), now ordered by
+// allfilms_pin_order ASC NULLS LAST then created_at DESC, filtered
+// to is_hidden_from_all_films=false. Mutation calls
+// revalidatePath('/') so the carousel reflects changes on the next
+// visit.
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { requireSuperAdminOr404 } from "@/lib/dal";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import AllFilmsCurator, {
+  type AllFilmsCurationItem,
+} from "./AllFilmsCurator";
+
+export const metadata: Metadata = {
+  title: "All Films curation · Moonbeem admin",
+  robots: { index: false, follow: false },
+};
+
+type TitleRow = {
+  id: string;
+  slug: string;
+  title: string;
+  year: number | null;
+  poster_url: string | null;
+  created_at: string;
+  allfilms_pin_order: number | null;
+  is_hidden_from_all_films: boolean;
+};
+
+// Bounded candidate pool. Catalog today is ~11 active movies; the
+// 100-row ceiling matches Recent for consistency and easily covers
+// near-future catalog growth.
+const CANDIDATE_POOL_LIMIT = 100;
+
+const TITLE_SELECT =
+  "id, slug, title, year, poster_url, created_at, allfilms_pin_order, is_hidden_from_all_films";
+
+function mapRow(r: TitleRow): AllFilmsCurationItem {
+  return {
+    id: r.id,
+    slug: r.slug,
+    title: r.title,
+    year: r.year,
+    poster_url: r.poster_url,
+    created_at: r.created_at,
+    allfilms_pin_order: r.allfilms_pin_order,
+    is_hidden_from_all_films: r.is_hidden_from_all_films,
+  };
+}
+
+export default async function AdminAllFilmsPage() {
+  await requireSuperAdminOr404();
+  const supabase = createServiceRoleClient();
+
+  // Single canonical gate on every list — is_public + is_active +
+  // media_type='movie'. We sort client-side into pinned / hidden /
+  // candidate buckets so the admin only sees rows the homepage
+  // would consider.
+  const { data: pinnedRaw } = await supabase
+    .from("titles")
+    .select(TITLE_SELECT)
+    .eq("is_public", true)
+    .eq("is_active", true)
+    .eq("media_type", "movie")
+    .not("allfilms_pin_order", "is", null)
+    .order("allfilms_pin_order", { ascending: true });
+
+  const { data: hiddenRaw } = await supabase
+    .from("titles")
+    .select(TITLE_SELECT)
+    .eq("is_public", true)
+    .eq("is_active", true)
+    .eq("media_type", "movie")
+    .eq("is_hidden_from_all_films", true)
+    .order("created_at", { ascending: false });
+
+  const { data: candidatesRaw } = await supabase
+    .from("titles")
+    .select(TITLE_SELECT)
+    .eq("is_public", true)
+    .eq("is_active", true)
+    .eq("media_type", "movie")
+    .is("allfilms_pin_order", null)
+    .eq("is_hidden_from_all_films", false)
+    .order("created_at", { ascending: false })
+    .limit(CANDIDATE_POOL_LIMIT);
+
+  const pinned = ((pinnedRaw ?? []) as TitleRow[]).map(mapRow);
+  const hidden = ((hiddenRaw ?? []) as TitleRow[]).map(mapRow);
+  const candidates = ((candidatesRaw ?? []) as TitleRow[]).map(mapRow);
+
+  return (
+    <div className="min-h-screen px-6 py-12 text-moonbeem-ink">
+      <div className="mx-auto flex max-w-3xl flex-col gap-8">
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="font-wordmark text-display-md text-moonbeem-pink m-0">
+            All Films curation
+          </h1>
+          <Link
+            href="/admin/homepage"
+            className="text-body-sm text-moonbeem-ink-muted hover:text-moonbeem-pink"
+          >
+            ← Back to homepage curation
+          </Link>
+        </div>
+        <p className="text-body text-moonbeem-ink-muted m-0">
+          Curate the homepage All Films carousel. Drag pinned rows to
+          reorder; X to unpin; Hide to remove from this carousel only
+          (Featured / partner pages still surface the title). Search
+          the candidate pool below to find more films to pin or hide.
+        </p>
+        <AllFilmsCurator
+          initialPinned={pinned}
+          initialHidden={hidden}
+          initialCandidates={candidates}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/homepage/page.tsx
+++ b/src/app/admin/homepage/page.tsx
@@ -40,10 +40,10 @@ const ENTRIES: CuratorEntry[] = [
     status: "live",
   },
   {
-    href: null,
+    href: "/admin/all-films",
     label: "All Films",
     description: "Per-title pin + hide overrides on the comprehensive catalog carousel.",
-    status: "coming-soon",
+    status: "live",
   },
   {
     href: null,

--- a/src/app/api/admin/titles/allfilms/reorder/route.ts
+++ b/src/app/api/admin/titles/allfilms/reorder/route.ts
@@ -1,0 +1,253 @@
+// POST /api/admin/titles/allfilms/reorder — super-admin curation of
+// the homepage All Films carousel. Mirrors
+// /api/admin/fan-edits/recent/reorder exactly but on titles. One
+// endpoint handles every state mutation (pin, unpin, reorder, hide,
+// unhide); the body is a complete declaration of the new pinned +
+// hidden state.
+//
+// Body shape:
+//   {
+//     pinned: [{ title_id: uuid, pin_order: 1..N }, …],
+//     hidden: [uuid, …]
+//   }
+//
+// Semantics: full-state declaration. Pinned-not-in-new → unpinned.
+// Hidden-not-in-new → unhidden. Hidden also clears any stale
+// pin_order to enforce the no-pin-while-hidden invariant.
+//
+// Canonical gate on every referenced title: is_public AND is_active
+// AND media_type='movie'. Caller (the curator UI) should never
+// declare an invalid candidate; this gate is the server backstop.
+//
+// Two-phase pin write (TEMP_OFFSET=10_000) future-proofs a potential
+// UNIQUE on allfilms_pin_order.
+//
+// revalidatePath('/') so the homepage reflects the new state on the
+// next visit.
+
+import { NextResponse, type NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { requireSuperAdmin } from "@/lib/dal";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import { enforce } from "@/lib/ratelimit";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const MAX_ENTRIES = 100;
+const TEMP_OFFSET = 10_000;
+
+type PinEntry = { title_id: string; pin_order: number };
+
+export async function POST(request: NextRequest) {
+  const session = await requireSuperAdmin();
+  const limit = await enforce(
+    "admin",
+    session.userId,
+    "admin/titles/allfilms/reorder",
+  );
+  if (!limit.ok) return limit.response;
+
+  let body: { pinned?: PinEntry[]; hidden?: string[] };
+  try {
+    body = (await request.json()) as {
+      pinned?: PinEntry[];
+      hidden?: string[];
+    };
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const pinnedIn = Array.isArray(body.pinned) ? body.pinned : [];
+  const hiddenIn = Array.isArray(body.hidden) ? body.hidden : [];
+
+  if (pinnedIn.length > MAX_ENTRIES) {
+    return NextResponse.json({ error: "too_many_pinned" }, { status: 400 });
+  }
+  if (hiddenIn.length > MAX_ENTRIES) {
+    return NextResponse.json({ error: "too_many_hidden" }, { status: 400 });
+  }
+
+  const pinnedSeenIds = new Set<string>();
+  const pinnedSeenPos = new Set<number>();
+  for (const e of pinnedIn) {
+    const tid = (e?.title_id ?? "").trim();
+    const pos = Number(e?.pin_order);
+    if (!UUID_RE.test(tid)) {
+      return NextResponse.json(
+        { error: "invalid_title_id" },
+        { status: 400 },
+      );
+    }
+    if (!Number.isInteger(pos) || pos < 1 || pos > MAX_ENTRIES) {
+      return NextResponse.json(
+        { error: "invalid_pin_order" },
+        { status: 400 },
+      );
+    }
+    if (pinnedSeenIds.has(tid)) {
+      return NextResponse.json(
+        { error: "duplicate_title_id" },
+        { status: 400 },
+      );
+    }
+    if (pinnedSeenPos.has(pos)) {
+      return NextResponse.json(
+        { error: "duplicate_pin_order" },
+        { status: 400 },
+      );
+    }
+    pinnedSeenIds.add(tid);
+    pinnedSeenPos.add(pos);
+  }
+
+  const hiddenSeen = new Set<string>();
+  for (const id of hiddenIn) {
+    const tid = (id ?? "").trim();
+    if (!UUID_RE.test(tid)) {
+      return NextResponse.json(
+        { error: "invalid_title_id" },
+        { status: 400 },
+      );
+    }
+    if (hiddenSeen.has(tid)) {
+      return NextResponse.json(
+        { error: "duplicate_hidden_id" },
+        { status: 400 },
+      );
+    }
+    hiddenSeen.add(tid);
+  }
+
+  for (const id of pinnedSeenIds) {
+    if (hiddenSeen.has(id)) {
+      return NextResponse.json(
+        { error: "title_both_pinned_and_hidden", title_id: id },
+        { status: 400 },
+      );
+    }
+  }
+
+  const supabase = createServiceRoleClient();
+
+  // Canonical All Films gate on every referenced title.
+  const referencedIds = [...pinnedSeenIds, ...hiddenSeen];
+  if (referencedIds.length > 0) {
+    const { data: valid, error: readErr } = await supabase
+      .from("titles")
+      .select("id")
+      .in("id", referencedIds)
+      .eq("is_public", true)
+      .eq("is_active", true)
+      .eq("media_type", "movie");
+    if (readErr) {
+      return NextResponse.json({ error: readErr.message }, { status: 500 });
+    }
+    const validSet = new Set((valid ?? []).map((r) => r.id as string));
+    for (const id of referencedIds) {
+      if (!validSet.has(id)) {
+        return NextResponse.json(
+          { error: "title_not_curatable", title_id: id },
+          { status: 400 },
+        );
+      }
+    }
+  }
+
+  // Current state lookup so we can diff and apply only the changes.
+  const [currentPinnedRes, currentHiddenRes] = await Promise.all([
+    supabase
+      .from("titles")
+      .select("id")
+      .not("allfilms_pin_order", "is", null),
+    supabase
+      .from("titles")
+      .select("id")
+      .eq("is_hidden_from_all_films", true),
+  ]);
+  if (currentPinnedRes.error) {
+    return NextResponse.json(
+      { error: currentPinnedRes.error.message },
+      { status: 500 },
+    );
+  }
+  if (currentHiddenRes.error) {
+    return NextResponse.json(
+      { error: currentHiddenRes.error.message },
+      { status: 500 },
+    );
+  }
+  const currentPinned = new Set(
+    (currentPinnedRes.data ?? []).map((r) => r.id as string),
+  );
+  const currentHidden = new Set(
+    (currentHiddenRes.data ?? []).map((r) => r.id as string),
+  );
+
+  const newPinned = pinnedSeenIds;
+  const newHidden = hiddenSeen;
+
+  // 1. Unpin anyone currently pinned but absent from new.
+  const toUnpin = [...currentPinned].filter((id) => !newPinned.has(id));
+  if (toUnpin.length > 0) {
+    const { error } = await supabase
+      .from("titles")
+      .update({ allfilms_pin_order: null })
+      .in("id", toUnpin);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  }
+
+  // 2. Unhide anyone currently hidden but absent from new.
+  const toUnhide = [...currentHidden].filter((id) => !newHidden.has(id));
+  if (toUnhide.length > 0) {
+    const { error } = await supabase
+      .from("titles")
+      .update({ is_hidden_from_all_films: false })
+      .in("id", toUnhide);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  }
+
+  // 3. Hide every id in newHidden (idempotent on already-hidden).
+  //    Also clears any stale pin_order — no-pin-while-hidden invariant.
+  if (newHidden.size > 0) {
+    const { error } = await supabase
+      .from("titles")
+      .update({ is_hidden_from_all_films: true, allfilms_pin_order: null })
+      .in("id", [...newHidden]);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  }
+
+  // 4. Two-phase pin write — bump to TEMP_OFFSET range, then settle.
+  if (pinnedIn.length > 0) {
+    for (let i = 0; i < pinnedIn.length; i++) {
+      const { error } = await supabase
+        .from("titles")
+        .update({
+          allfilms_pin_order: TEMP_OFFSET + i,
+          is_hidden_from_all_films: false,
+        })
+        .eq("id", pinnedIn[i].title_id);
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+    }
+    for (const e of pinnedIn) {
+      const { error } = await supabase
+        .from("titles")
+        .update({ allfilms_pin_order: e.pin_order })
+        .eq("id", e.title_id);
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+    }
+  }
+
+  revalidatePath("/");
+  return NextResponse.json({ success: true });
+}

--- a/src/lib/queries/titles.ts
+++ b/src/lib/queries/titles.ts
@@ -209,6 +209,12 @@ export async function getAllFilms(): Promise<Title[]> {
     .eq("is_public", true)
     .eq("is_active", true)
     .eq("media_type", "movie")
+    .eq("is_hidden_from_all_films", false)
+    // Pinned rows (allfilms_pin_order NOT NULL, ASC NULLS LAST) take
+    // the top slots; the rest fill from created_at DESC. No LIMIT —
+    // All Films is the comprehensive "everything" carousel; pinning
+    // promotes a small set to the top, never excludes anything.
+    .order("allfilms_pin_order", { ascending: true, nullsFirst: false })
     .order("created_at", { ascending: false });
   if (error || !data) return [];
   return data as Title[];

--- a/supabase/migrations/20260526000002_titles_allfilms_curation.sql
+++ b/supabase/migrations/20260526000002_titles_allfilms_curation.sql
@@ -1,0 +1,36 @@
+-- Add per-title columns for super-admin curation of the homepage
+-- All Films carousel. Today the carousel uses created_at DESC; this
+-- migration leaves all rows with no curation overrides on rollout
+-- (allfilms_pin_order NULL on every row, is_hidden_from_all_films
+-- FALSE). The /admin/all-films page (shipping in the same commit) is
+-- the first surface that mutates these columns.
+--
+-- Defaults & invariants:
+--   - allfilms_pin_order INTEGER NULL — pinned position; NULL = not
+--     pinned; smaller numbers = higher pin position. The homepage
+--     query renders pinned rows first (ORDER BY allfilms_pin_order
+--     ASC NULLS LAST), then the remaining rows fill from created_at
+--     DESC. All Films is an "everything" list (no LIMIT) so pinning
+--     just promotes a small set to the top, never excludes anything.
+--   - is_hidden_from_all_films BOOLEAN NOT NULL DEFAULT FALSE —
+--     excludes a title from the All Films carousel ONLY. Per-carousel
+--     hide, not a global hide: a featured title can be hidden from
+--     All Films but stay on Featured, matching the comment in
+--     getAllFilms that "Featured titles intentionally appear in BOTH
+--     Featured and All Films."
+--   - No index. titles.media_type='movie' is ~11 rows today; pinned
+--     subset stays tiny.
+--   - Parallel-but-distinct from is_featured + featured_order
+--     (20260512000007). A title can be in BOTH Featured and All Films
+--     with INDEPENDENT pin orders and hide flags in each — the two
+--     carousels are separate editorial surfaces.
+--   - Per-carousel naming follows the Recent precedent
+--     (fan_edits.recent_pin_order from 20260526000001). The
+--     "allfilms_" prefix leaves room for parallel trending_pin_order
+--     in Slice C without column-name collisions.
+--
+-- Mirrors 20260526000001 (fan_edits_recent_curation) but on titles.
+
+alter table public.titles
+  add column if not exists allfilms_pin_order integer,
+  add column if not exists is_hidden_from_all_films boolean not null default false;


### PR DESCRIPTION
Second slice of homepage carousel curation, mechanically close to slice B (PR #18) but on `titles` instead of `fan_edits`.

## What ships

**Migration `20260526000002_titles_allfilms_curation.sql`** (already applied to prod):
- `titles.allfilms_pin_order` (INT NULL)
- `titles.is_hidden_from_all_films` (BOOL NOT NULL DEFAULT FALSE)

Parallel-but-distinct from `is_featured` + `featured_order` — a title can be in BOTH Featured and All Films with independent curation per surface.

**`getAllFilms` update:** adds `is_hidden_from_all_films=false` + ORDER BY `allfilms_pin_order ASC NULLS LAST, created_at DESC`. No LIMIT change — All Films is the comprehensive "everything" carousel.

**`/admin/all-films` curator** mirrors `RecentEditsCurator`'s three-section shape (Pinned drag-reorder / Hidden / Candidates with filter) on titles.

**`/api/admin/titles/allfilms/reorder` API**: same full-state declaration pattern as slice B's recent/reorder. Server backstop validates the canonical `is_public + is_active + media_type='movie'` gate.

**`/admin/homepage` hub:** All Films flips from "coming soon" to a live card. Trending Edits stays disabled pending slice C.

## Scope

6 files (+892, −2). `npm run build` clean. No changes to slice B's surfaces (Recent Edits curator + API are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)