### PR TITLE
homepage curation slice C: Trending Edits hide+pin (pinned + algorithm merge)

### DIFF
--- a/src/app/admin/homepage/page.tsx
+++ b/src/app/admin/homepage/page.tsx
@@ -46,11 +46,11 @@ const ENTRIES: CuratorEntry[] = [
     status: "live",
   },
   {
-    href: null,
+    href: "/admin/trending-edits",
     label: "Trending Edits",
     description:
-      "Per-fan_edit pin + hide overrides layered onto the 24h-delta algorithm.",
-    status: "coming-soon",
+      "Per-fan_edit pin + hide overrides layered onto the 24h-delta algorithm. Pin bypasses snapshot-coverage.",
+    status: "live",
   },
 ];
 

--- a/src/app/admin/trending-edits/TrendingEditsCurator.tsx
+++ b/src/app/admin/trending-edits/TrendingEditsCurator.tsx
@@ -1,0 +1,483 @@
+"use client";
+
+// Client curator for /admin/trending-edits. Mechanical clone of
+// RecentEditsCurator with column-name swaps (trending_pin_order
+// instead of recent_pin_order, is_hidden_from_trending instead of
+// is_hidden_from_recent, API endpoint
+// /api/admin/fan-edits/trending/reorder). Three sections — Pinned
+// (drag-reorder via dnd-kit), Hidden (toggle to unhide), Candidates
+// (top 100 pool, client-side filter). Every state change posts the
+// full pinned+hidden state to the API; full-state-declaration
+// semantics.
+//
+// Behavioral note for Trending specifically: pinning bypasses the
+// homepage algorithm's snapshot-coverage requirement, so a fan_edit
+// with no view-tracking history can be pinned and shown. The
+// curator's data loader (page.tsx) still requires
+// view_tracking_status='active' so dead-on-platform / private rows
+// don't appear in any of the three lists.
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  fetchJson,
+  FetchJsonError,
+  RateLimitedError,
+} from "@/lib/fetch-json";
+
+export type TrendingCurationItem = {
+  id: string;
+  title_id: string;
+  title_name: string;
+  title_slug: string;
+  title_poster_url: string | null;
+  platform: "tiktok" | "instagram" | "youtube" | "twitter";
+  thumbnail_url: string | null;
+  creator_handle: string;
+  created_at: string;
+  trending_pin_order: number | null;
+  is_hidden_from_trending: boolean;
+};
+
+type Props = {
+  initialPinned: TrendingCurationItem[];
+  initialHidden: TrendingCurationItem[];
+  initialCandidates: TrendingCurationItem[];
+};
+
+function sortByCreatedDesc(
+  a: TrendingCurationItem,
+  b: TrendingCurationItem,
+) {
+  return b.created_at.localeCompare(a.created_at);
+}
+
+export default function TrendingEditsCurator({
+  initialPinned,
+  initialHidden,
+  initialCandidates,
+}: Props) {
+  const router = useRouter();
+  const [pinned, setPinned] =
+    useState<TrendingCurationItem[]>(initialPinned);
+  const [hidden, setHidden] =
+    useState<TrendingCurationItem[]>(initialHidden);
+  const [candidates, setCandidates] = useState<TrendingCurationItem[]>(
+    [...initialCandidates].sort(sortByCreatedDesc),
+  );
+  const [filter, setFilter] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  );
+
+  const filteredCandidates = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return candidates;
+    return candidates.filter((c) => {
+      if (c.title_name.toLowerCase().includes(q)) return true;
+      if (c.creator_handle.toLowerCase().includes(q)) return true;
+      if (c.platform.toLowerCase().includes(q)) return true;
+      return false;
+    });
+  }, [candidates, filter]);
+
+  async function persist(
+    nextPinned: TrendingCurationItem[],
+    nextHidden: TrendingCurationItem[],
+  ): Promise<boolean> {
+    setSaving(true);
+    setErrorMsg(null);
+    try {
+      await fetchJson("/api/admin/fan-edits/trending/reorder", {
+        method: "POST",
+        body: {
+          pinned: nextPinned.map((p, idx) => ({
+            fan_edit_id: p.id,
+            pin_order: idx + 1,
+          })),
+          hidden: nextHidden.map((h) => h.id),
+        },
+      });
+      router.refresh();
+      return true;
+    } catch (err) {
+      setErrorMsg(
+        err instanceof RateLimitedError || err instanceof FetchJsonError
+          ? err.userMessage
+          : err instanceof Error
+            ? err.message
+            : String(err),
+      );
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = pinned.findIndex((p) => p.id === active.id);
+    const newIndex = pinned.findIndex((p) => p.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+    const prev = pinned;
+    const next = arrayMove(pinned, oldIndex, newIndex);
+    setPinned(next);
+    const ok = await persist(next, hidden);
+    if (!ok) setPinned(prev);
+  }
+
+  async function handlePinCandidate(item: TrendingCurationItem) {
+    if (busyId) return;
+    setBusyId(item.id);
+    const prevPinned = pinned;
+    const prevCandidates = candidates;
+    const nextPinned = [
+      ...pinned,
+      { ...item, trending_pin_order: pinned.length + 1 },
+    ];
+    const nextCandidates = candidates.filter((c) => c.id !== item.id);
+    setPinned(nextPinned);
+    setCandidates(nextCandidates);
+    const ok = await persist(nextPinned, hidden);
+    if (!ok) {
+      setPinned(prevPinned);
+      setCandidates(prevCandidates);
+    }
+    setBusyId(null);
+  }
+
+  async function handleUnpin(item: TrendingCurationItem) {
+    if (busyId) return;
+    setBusyId(item.id);
+    const prevPinned = pinned;
+    const prevCandidates = candidates;
+    const nextPinned = pinned.filter((p) => p.id !== item.id);
+    const nextCandidates = [
+      { ...item, trending_pin_order: null },
+      ...candidates,
+    ].sort(sortByCreatedDesc);
+    setPinned(nextPinned);
+    setCandidates(nextCandidates);
+    const ok = await persist(nextPinned, hidden);
+    if (!ok) {
+      setPinned(prevPinned);
+      setCandidates(prevCandidates);
+    }
+    setBusyId(null);
+  }
+
+  async function handleHide(
+    item: TrendingCurationItem,
+    from: "pinned" | "candidates",
+  ) {
+    if (busyId) return;
+    setBusyId(item.id);
+    const prevPinned = pinned;
+    const prevCandidates = candidates;
+    const prevHidden = hidden;
+    const nextPinned =
+      from === "pinned" ? pinned.filter((p) => p.id !== item.id) : pinned;
+    const nextCandidates =
+      from === "candidates"
+        ? candidates.filter((c) => c.id !== item.id)
+        : candidates;
+    const nextHidden = [
+      {
+        ...item,
+        trending_pin_order: null,
+        is_hidden_from_trending: true,
+      },
+      ...hidden,
+    ];
+    setPinned(nextPinned);
+    setCandidates(nextCandidates);
+    setHidden(nextHidden);
+    const ok = await persist(nextPinned, nextHidden);
+    if (!ok) {
+      setPinned(prevPinned);
+      setCandidates(prevCandidates);
+      setHidden(prevHidden);
+    }
+    setBusyId(null);
+  }
+
+  async function handleUnhide(item: TrendingCurationItem) {
+    if (busyId) return;
+    setBusyId(item.id);
+    const prevHidden = hidden;
+    const prevCandidates = candidates;
+    const nextHidden = hidden.filter((h) => h.id !== item.id);
+    const nextCandidates = [
+      { ...item, is_hidden_from_trending: false },
+      ...candidates,
+    ].sort(sortByCreatedDesc);
+    setHidden(nextHidden);
+    setCandidates(nextCandidates);
+    const ok = await persist(pinned, nextHidden);
+    if (!ok) {
+      setHidden(prevHidden);
+      setCandidates(prevCandidates);
+    }
+    setBusyId(null);
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      {errorMsg && (
+        <p className="text-body-sm text-moonbeem-magenta">{errorMsg}</p>
+      )}
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-display-sm m-0">Pinned ({pinned.length})</h2>
+        {pinned.length === 0 ? (
+          <p className="text-body text-moonbeem-ink-muted">
+            No pinned edits. Pin from the candidate pool below to
+            override the algorithmic ranking.
+          </p>
+        ) : (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={pinned.map((p) => p.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              <ul
+                className={`flex flex-col gap-2 ${saving ? "opacity-70" : ""}`}
+                aria-busy={saving}
+              >
+                {pinned.map((p, idx) => (
+                  <SortablePinnedRow
+                    key={p.id}
+                    item={p}
+                    position={idx + 1}
+                    onUnpin={() => handleUnpin(p)}
+                    onHide={() => handleHide(p, "pinned")}
+                    isBusy={busyId === p.id}
+                  />
+                ))}
+              </ul>
+            </SortableContext>
+          </DndContext>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-display-sm m-0">Hidden ({hidden.length})</h2>
+        {hidden.length === 0 ? (
+          <p className="text-body text-moonbeem-ink-muted">
+            No hidden edits.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {hidden.map((h) => (
+              <li
+                key={h.id}
+                className="flex items-center gap-3 rounded-md border border-white/10 bg-white/[0.02] px-3 py-2"
+              >
+                <FanEditThumb item={h} />
+                <FanEditMeta item={h} />
+                <button
+                  type="button"
+                  onClick={() => handleUnhide(h)}
+                  disabled={busyId === h.id || saving}
+                  className="rounded-md border border-white/10 px-3 py-1 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-pink hover:text-moonbeem-pink disabled:opacity-40"
+                >
+                  Unhide
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-display-sm m-0">
+          Candidates ({filteredCandidates.length}
+          {filter ? ` / ${candidates.length}` : ""})
+        </h2>
+        <p className="text-caption text-moonbeem-ink-subtle m-0">
+          Top {candidates.length} most-recent fan edits not pinned and
+          not hidden. Filter to find an edit, then pin or hide it.
+          Pinning a candidate with no view-tracking history yet still
+          surfaces it on Trending — pin bypasses the algorithm's
+          snapshot-coverage requirement.
+        </p>
+        <input
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Filter by title, creator handle, or platform…"
+          className="rounded-md border border-white/10 bg-black/30 px-3 py-2 text-body-sm text-moonbeem-ink placeholder:text-moonbeem-ink-subtle focus:border-moonbeem-pink focus:outline-none"
+        />
+        {filteredCandidates.length === 0 ? (
+          <p className="text-body-sm text-moonbeem-ink-muted">
+            No candidates match.
+          </p>
+        ) : (
+          <ul className="max-h-[600px] flex-col gap-2 overflow-y-auto flex">
+            {filteredCandidates.map((c) => (
+              <li
+                key={c.id}
+                className="flex items-center gap-3 rounded-md border border-white/10 bg-white/[0.02] px-3 py-2"
+              >
+                <FanEditThumb item={c} />
+                <FanEditMeta item={c} />
+                <button
+                  type="button"
+                  onClick={() => handlePinCandidate(c)}
+                  disabled={busyId === c.id || saving}
+                  className="rounded-md border border-white/10 px-3 py-1 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-pink hover:text-moonbeem-pink disabled:opacity-40"
+                >
+                  Pin
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleHide(c, "candidates")}
+                  disabled={busyId === c.id || saving}
+                  aria-label={`Hide ${c.title_name}`}
+                  className="rounded-md border border-white/10 px-3 py-1 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-magenta hover:text-moonbeem-magenta disabled:opacity-40"
+                >
+                  Hide
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function FanEditThumb({ item }: { item: TrendingCurationItem }) {
+  if (!item.thumbnail_url) {
+    return (
+      <div
+        className="h-[60px] w-[40px] shrink-0 rounded-sm border border-white/10 bg-white/[0.03]"
+        aria-hidden="true"
+      />
+    );
+  }
+  return (
+    <div className="h-[60px] w-[40px] shrink-0 overflow-hidden rounded-sm bg-white/[0.03]">
+      <Image
+        src={item.thumbnail_url}
+        alt={`${item.title_name} fan edit thumbnail`}
+        width={40}
+        height={60}
+        className="h-full w-full object-cover"
+        unoptimized
+      />
+    </div>
+  );
+}
+
+function FanEditMeta({ item }: { item: TrendingCurationItem }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="truncate text-body-sm text-moonbeem-ink">
+        {item.title_name}
+      </div>
+      <div className="truncate font-mono text-caption text-moonbeem-ink-subtle">
+        @{item.creator_handle} · {item.platform}
+      </div>
+    </div>
+  );
+}
+
+function SortablePinnedRow({
+  item,
+  position,
+  onUnpin,
+  onHide,
+  isBusy,
+}: {
+  item: TrendingCurationItem;
+  position: number;
+  onUnpin: () => void;
+  onHide: () => void;
+  isBusy: boolean;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 20 : undefined,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-3 rounded-md border bg-white/[0.02] px-3 py-2 ${
+        isDragging
+          ? "border-moonbeem-pink shadow-[0_8px_24px_rgba(245,197,225,0.25)]"
+          : "border-white/10"
+      }`}
+    >
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        aria-label={`Drag ${item.title_name} to reorder`}
+        className="cursor-grab touch-none px-1 text-moonbeem-ink-subtle hover:text-moonbeem-ink"
+      >
+        ⋮⋮
+      </button>
+      <span className="w-6 shrink-0 text-right font-mono text-body-sm text-moonbeem-ink-subtle tabular-nums">
+        {position}
+      </span>
+      <FanEditThumb item={item} />
+      <FanEditMeta item={item} />
+      <button
+        type="button"
+        onClick={onHide}
+        disabled={isBusy}
+        aria-label={`Hide ${item.title_name}`}
+        className="rounded-md border border-white/10 px-2.5 py-1 text-caption text-moonbeem-ink-muted transition-colors hover:border-moonbeem-magenta hover:text-moonbeem-magenta disabled:opacity-40"
+      >
+        Hide
+      </button>
+      <button
+        type="button"
+        onClick={onUnpin}
+        disabled={isBusy}
+        aria-label={`Unpin ${item.title_name}`}
+        className="h-7 w-7 shrink-0 rounded-full border border-white/10 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-magenta hover:text-moonbeem-magenta disabled:opacity-40"
+      >
+        ×
+      </button>
+    </li>
+  );
+}

--- a/src/app/admin/trending-edits/page.tsx
+++ b/src/app/admin/trending-edits/page.tsx
@@ -1,0 +1,194 @@
+// /admin/trending-edits — super-admin curation of the homepage
+// Trending Edits carousel. Mirrors /admin/recent-edits's three-
+// section shape (Pinned / Hidden / Candidates) but with one
+// important behavioral difference, documented in the page copy:
+// pinning a fan_edit on Trending BYPASSES SNAPSHOT-COVERAGE. The
+// homepage Trending query has an inner-join requirement (latest +
+// ≥24h-ago snapshots) that the algorithmic delta needs; pinned
+// rows skip that requirement entirely, so an admin can pin a
+// freshly-imported fan_edit and it surfaces immediately.
+//
+// All three lists (pinned, hidden, candidates) honor the canonical
+// fan_edit gate (is_active + verification_status + deleted_at IS
+// NULL) AND view_tracking_status='active' — same gate the homepage
+// query uses, so the curator never shows a row the homepage would
+// reject.
+//
+// Mutation calls revalidatePath('/') via the API route so the
+// homepage reflects changes on the next visit.
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { requireSuperAdminOr404 } from "@/lib/dal";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import { PUBLICLY_READABLE_FAN_EDIT_STATUSES } from "@/lib/fan-edits/status";
+import TrendingEditsCurator, {
+  type TrendingCurationItem,
+} from "./TrendingEditsCurator";
+
+export const metadata: Metadata = {
+  title: "Trending Edits curation · Moonbeem admin",
+  robots: { index: false, follow: false },
+};
+
+type FanEditRow = {
+  id: string;
+  title_id: string;
+  platform: "tiktok" | "instagram" | "youtube" | "twitter";
+  embed_url: string;
+  thumbnail_url: string | null;
+  creator_handle_displayed: string | null;
+  creator_id: string | null;
+  created_at: string;
+  trending_pin_order: number | null;
+  is_hidden_from_trending: boolean;
+  titles: {
+    slug: string;
+    title: string;
+    poster_url: string | null;
+    is_active: boolean;
+  } | null;
+};
+
+const CANDIDATE_POOL_LIMIT = 100;
+
+const FAN_EDIT_SELECT =
+  "id, title_id, platform, embed_url, thumbnail_url, creator_handle_displayed, creator_id, created_at, trending_pin_order, is_hidden_from_trending, titles!inner(slug, title, poster_url, is_active)";
+
+function mapRow(
+  r: FanEditRow,
+  creatorHandleById: Map<string, string>,
+): TrendingCurationItem | null {
+  if (!r.titles) return null;
+  const moonbeemHandle = r.creator_id
+    ? (creatorHandleById.get(r.creator_id) ?? null)
+    : null;
+  return {
+    id: r.id,
+    title_id: r.title_id,
+    title_name: r.titles.title,
+    title_slug: r.titles.slug,
+    title_poster_url: r.titles.poster_url,
+    platform: r.platform,
+    thumbnail_url: r.thumbnail_url,
+    creator_handle:
+      moonbeemHandle ?? r.creator_handle_displayed ?? "anon",
+    created_at: r.created_at,
+    trending_pin_order: r.trending_pin_order,
+    is_hidden_from_trending: r.is_hidden_from_trending,
+  };
+}
+
+export default async function AdminTrendingEditsPage() {
+  await requireSuperAdminOr404();
+  const supabase = createServiceRoleClient();
+
+  // All three queries share the canonical fan_edit gate + view-
+  // tracking-active filter. View-tracking-active is preserved here
+  // (and in the homepage's getTrendingFanEdits) so dead-on-platform
+  // / private rows can't be pinned or hidden — pin would render a
+  // broken embed; hide is meaningless for a row that's already
+  // unrenderable.
+  const { data: pinnedRaw } = await supabase
+    .from("fan_edits")
+    .select(FAN_EDIT_SELECT)
+    .eq("is_active", true)
+    .in("verification_status", PUBLICLY_READABLE_FAN_EDIT_STATUSES)
+    .eq("view_tracking_status", "active")
+    .is("deleted_at", null)
+    .eq("titles.is_active", true)
+    .not("trending_pin_order", "is", null)
+    .order("trending_pin_order", { ascending: true });
+
+  const { data: hiddenRaw } = await supabase
+    .from("fan_edits")
+    .select(FAN_EDIT_SELECT)
+    .eq("is_active", true)
+    .in("verification_status", PUBLICLY_READABLE_FAN_EDIT_STATUSES)
+    .eq("view_tracking_status", "active")
+    .is("deleted_at", null)
+    .eq("titles.is_active", true)
+    .eq("is_hidden_from_trending", true)
+    .order("created_at", { ascending: false });
+
+  const { data: candidatesRaw } = await supabase
+    .from("fan_edits")
+    .select(FAN_EDIT_SELECT)
+    .eq("is_active", true)
+    .in("verification_status", PUBLICLY_READABLE_FAN_EDIT_STATUSES)
+    .eq("view_tracking_status", "active")
+    .is("deleted_at", null)
+    .eq("titles.is_active", true)
+    .is("trending_pin_order", null)
+    .eq("is_hidden_from_trending", false)
+    .order("created_at", { ascending: false })
+    .limit(CANDIDATE_POOL_LIMIT);
+
+  const pinnedRows = (pinnedRaw ?? []) as unknown as FanEditRow[];
+  const hiddenRows = (hiddenRaw ?? []) as unknown as FanEditRow[];
+  const candidateRows = (candidatesRaw ?? []) as unknown as FanEditRow[];
+
+  const creatorIds = Array.from(
+    new Set(
+      [...pinnedRows, ...hiddenRows, ...candidateRows]
+        .map((r) => r.creator_id)
+        .filter((id): id is string => !!id),
+    ),
+  );
+  const creatorHandleById = new Map<string, string>();
+  if (creatorIds.length > 0) {
+    const { data: creators } = await supabase
+      .from("public_creators")
+      .select("id, moonbeem_handle")
+      .in("id", creatorIds);
+    for (const c of (creators ?? []) as Array<{
+      id: string;
+      moonbeem_handle: string;
+    }>) {
+      creatorHandleById.set(c.id, c.moonbeem_handle);
+    }
+  }
+
+  const pinned = pinnedRows
+    .map((r) => mapRow(r, creatorHandleById))
+    .filter((x): x is TrendingCurationItem => x !== null);
+  const hidden = hiddenRows
+    .map((r) => mapRow(r, creatorHandleById))
+    .filter((x): x is TrendingCurationItem => x !== null);
+  const candidates = candidateRows
+    .map((r) => mapRow(r, creatorHandleById))
+    .filter((x): x is TrendingCurationItem => x !== null);
+
+  return (
+    <div className="min-h-screen px-6 py-12 text-moonbeem-ink">
+      <div className="mx-auto flex max-w-3xl flex-col gap-8">
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="font-wordmark text-display-md text-moonbeem-pink m-0">
+            Trending Edits curation
+          </h1>
+          <Link
+            href="/admin/homepage"
+            className="text-body-sm text-moonbeem-ink-muted hover:text-moonbeem-pink"
+          >
+            ← Back to homepage curation
+          </Link>
+        </div>
+        <p className="text-body text-moonbeem-ink-muted m-0">
+          Curate the homepage Trending Edits carousel. Trending is
+          algorithmic — fan_edits with a 24h view-count delta are
+          ranked DESC and the top N fill the carousel. Pinning a
+          fan_edit overrides the algorithm AND bypasses the snapshot-
+          coverage requirement, so a freshly-imported edit (no
+          view-tracking history yet) can be pinned and shown
+          immediately. Hide removes a fan_edit from Trending only;
+          Recent / Featured surfaces are unaffected.
+        </p>
+        <TrendingEditsCurator
+          initialPinned={pinned}
+          initialHidden={hidden}
+          initialCandidates={candidates}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/fan-edits/trending/reorder/route.ts
+++ b/src/app/api/admin/fan-edits/trending/reorder/route.ts
@@ -1,0 +1,256 @@
+// POST /api/admin/fan-edits/trending/reorder — super-admin curation
+// of the homepage Trending Edits carousel. Mechanical clone of
+// /api/admin/fan-edits/recent/reorder with column-name swaps
+// (trending_pin_order, is_hidden_from_trending) and an extra
+// view_tracking_status='active' clause on the canonical-gate
+// backstop (so dead-on-platform / private rows can't be pinned or
+// hidden — pin would render a broken embed).
+//
+// Body shape:
+//   {
+//     pinned: [{ fan_edit_id: uuid, pin_order: 1..N }, …],
+//     hidden: [uuid, …]
+//   }
+//
+// Semantics: full-state declaration. Pinned-not-in-new → unpinned;
+// hidden-not-in-new → unhidden. Hide also clears any stale
+// pin_order to enforce the no-pin-while-hidden invariant. Two-phase
+// pin write (TEMP_OFFSET = 10_000) future-proofs a potential UNIQUE
+// on trending_pin_order.
+//
+// revalidatePath('/') on success.
+
+import { NextResponse, type NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { requireSuperAdmin } from "@/lib/dal";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import { enforce } from "@/lib/ratelimit";
+import { PUBLICLY_READABLE_FAN_EDIT_STATUSES } from "@/lib/fan-edits/status";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const MAX_ENTRIES = 100;
+const TEMP_OFFSET = 10_000;
+
+type PinEntry = { fan_edit_id: string; pin_order: number };
+
+export async function POST(request: NextRequest) {
+  const session = await requireSuperAdmin();
+  const limit = await enforce(
+    "admin",
+    session.userId,
+    "admin/fan-edits/trending/reorder",
+  );
+  if (!limit.ok) return limit.response;
+
+  let body: { pinned?: PinEntry[]; hidden?: string[] };
+  try {
+    body = (await request.json()) as {
+      pinned?: PinEntry[];
+      hidden?: string[];
+    };
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const pinnedIn = Array.isArray(body.pinned) ? body.pinned : [];
+  const hiddenIn = Array.isArray(body.hidden) ? body.hidden : [];
+
+  if (pinnedIn.length > MAX_ENTRIES) {
+    return NextResponse.json({ error: "too_many_pinned" }, { status: 400 });
+  }
+  if (hiddenIn.length > MAX_ENTRIES) {
+    return NextResponse.json({ error: "too_many_hidden" }, { status: 400 });
+  }
+
+  const pinnedSeenIds = new Set<string>();
+  const pinnedSeenPos = new Set<number>();
+  for (const e of pinnedIn) {
+    const fid = (e?.fan_edit_id ?? "").trim();
+    const pos = Number(e?.pin_order);
+    if (!UUID_RE.test(fid)) {
+      return NextResponse.json(
+        { error: "invalid_fan_edit_id" },
+        { status: 400 },
+      );
+    }
+    if (!Number.isInteger(pos) || pos < 1 || pos > MAX_ENTRIES) {
+      return NextResponse.json(
+        { error: "invalid_pin_order" },
+        { status: 400 },
+      );
+    }
+    if (pinnedSeenIds.has(fid)) {
+      return NextResponse.json(
+        { error: "duplicate_fan_edit_id" },
+        { status: 400 },
+      );
+    }
+    if (pinnedSeenPos.has(pos)) {
+      return NextResponse.json(
+        { error: "duplicate_pin_order" },
+        { status: 400 },
+      );
+    }
+    pinnedSeenIds.add(fid);
+    pinnedSeenPos.add(pos);
+  }
+
+  const hiddenSeen = new Set<string>();
+  for (const id of hiddenIn) {
+    const fid = (id ?? "").trim();
+    if (!UUID_RE.test(fid)) {
+      return NextResponse.json(
+        { error: "invalid_fan_edit_id" },
+        { status: 400 },
+      );
+    }
+    if (hiddenSeen.has(fid)) {
+      return NextResponse.json(
+        { error: "duplicate_hidden_id" },
+        { status: 400 },
+      );
+    }
+    hiddenSeen.add(fid);
+  }
+
+  for (const id of pinnedSeenIds) {
+    if (hiddenSeen.has(id)) {
+      return NextResponse.json(
+        { error: "fan_edit_both_pinned_and_hidden", fan_edit_id: id },
+        { status: 400 },
+      );
+    }
+  }
+
+  const supabase = createServiceRoleClient();
+
+  // Canonical fan_edit gate + view_tracking_status='active' on every
+  // referenced fan_edit. Matches the curator's data-loader gate and
+  // the homepage getTrendingFanEdits gate, so pinning a dead-on-
+  // platform / private row is impossible by construction.
+  const referencedIds = [...pinnedSeenIds, ...hiddenSeen];
+  if (referencedIds.length > 0) {
+    const { data: valid, error: readErr } = await supabase
+      .from("fan_edits")
+      .select("id")
+      .in("id", referencedIds)
+      .eq("is_active", true)
+      .in("verification_status", PUBLICLY_READABLE_FAN_EDIT_STATUSES)
+      .eq("view_tracking_status", "active")
+      .is("deleted_at", null);
+    if (readErr) {
+      return NextResponse.json({ error: readErr.message }, { status: 500 });
+    }
+    const validSet = new Set((valid ?? []).map((r) => r.id as string));
+    for (const id of referencedIds) {
+      if (!validSet.has(id)) {
+        return NextResponse.json(
+          { error: "fan_edit_not_curatable", fan_edit_id: id },
+          { status: 400 },
+        );
+      }
+    }
+  }
+
+  // Current state lookup so we can diff and apply only the changes.
+  const [currentPinnedRes, currentHiddenRes] = await Promise.all([
+    supabase
+      .from("fan_edits")
+      .select("id")
+      .not("trending_pin_order", "is", null),
+    supabase
+      .from("fan_edits")
+      .select("id")
+      .eq("is_hidden_from_trending", true),
+  ]);
+  if (currentPinnedRes.error) {
+    return NextResponse.json(
+      { error: currentPinnedRes.error.message },
+      { status: 500 },
+    );
+  }
+  if (currentHiddenRes.error) {
+    return NextResponse.json(
+      { error: currentHiddenRes.error.message },
+      { status: 500 },
+    );
+  }
+  const currentPinned = new Set(
+    (currentPinnedRes.data ?? []).map((r) => r.id as string),
+  );
+  const currentHidden = new Set(
+    (currentHiddenRes.data ?? []).map((r) => r.id as string),
+  );
+
+  const newPinned = pinnedSeenIds;
+  const newHidden = hiddenSeen;
+
+  // 1. Unpin anyone currently pinned but absent from new.
+  const toUnpin = [...currentPinned].filter((id) => !newPinned.has(id));
+  if (toUnpin.length > 0) {
+    const { error } = await supabase
+      .from("fan_edits")
+      .update({ trending_pin_order: null })
+      .in("id", toUnpin);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  }
+
+  // 2. Unhide anyone currently hidden but absent from new.
+  const toUnhide = [...currentHidden].filter((id) => !newHidden.has(id));
+  if (toUnhide.length > 0) {
+    const { error } = await supabase
+      .from("fan_edits")
+      .update({ is_hidden_from_trending: false })
+      .in("id", toUnhide);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  }
+
+  // 3. Hide every id in newHidden (idempotent on already-hidden).
+  //    Also clears any stale pin_order — no-pin-while-hidden invariant.
+  if (newHidden.size > 0) {
+    const { error } = await supabase
+      .from("fan_edits")
+      .update({
+        is_hidden_from_trending: true,
+        trending_pin_order: null,
+      })
+      .in("id", [...newHidden]);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  }
+
+  // 4. Two-phase pin write — bump to TEMP_OFFSET range, then settle.
+  if (pinnedIn.length > 0) {
+    for (let i = 0; i < pinnedIn.length; i++) {
+      const { error } = await supabase
+        .from("fan_edits")
+        .update({
+          trending_pin_order: TEMP_OFFSET + i,
+          is_hidden_from_trending: false,
+        })
+        .eq("id", pinnedIn[i].fan_edit_id);
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+    }
+    for (const e of pinnedIn) {
+      const { error } = await supabase
+        .from("fan_edits")
+        .update({ trending_pin_order: e.pin_order })
+        .eq("id", e.fan_edit_id);
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+    }
+  }
+
+  revalidatePath("/");
+  return NextResponse.json({ success: true });
+}

--- a/src/lib/queries/titles.ts
+++ b/src/lib/queries/titles.ts
@@ -734,25 +734,43 @@ export async function getFanEditsForCreator(
   }));
 }
 
-// Trending fan edits — top N by view-count delta over the past 24h.
-// Uses existing view_tracking_snapshots data (no new schema, no new
-// cron, no first-run NULL trap). Snapshots are written by the
-// view-tracking Edge Function every ~20h per fan_edit; 39% of
-// active fan_edits have at least one snapshot from ≥24h ago as of
-// the initial deploy, growing as the cron continues to populate
-// history.
+// Trending fan edits — pinned rows first, then the top N-pinned by
+// view-count delta over the past 24h.
 //
-// Algorithm:
-//   1. Fetch all snapshots for active fan_edits in a single round
-//      trip. 847 rows total today — well under any limit.
-//   2. Group by fan_edit_id: pick the LATEST snapshot and the
-//      most-recent snapshot ≤24h ago.
-//   3. Rows with BOTH a latest and a 24h-prior snapshot get a
-//      delta. Rows with only a latest (recently ingested, no
-//      history) are excluded — they're noise for a "trending"
-//      ranking.
-//   4. Order by delta DESC, limit N, then hydrate with title +
-//      creator handle joins to match FanEditWithTitle shape.
+// Slice C (homepage curation) restructured this from a single
+// algorithmic query into two-queries-then-merge:
+//
+//   Query 1 — fetchPinnedTrending: rows with trending_pin_order
+//     NOT NULL, ordered by trending_pin_order ASC. Bypasses the
+//     snapshot-coverage filter the algorithm imposes — a pinned
+//     fan_edit shows on Trending even if it lacks the two-endpoint
+//     (latest + ≥24h ago) snapshot window. Still honors the
+//     canonical three-clause gate AND view_tracking_status =
+//     'active' so dead/private rows can't render as broken embeds.
+//
+//   Query 2 — fetchAlgorithmicTrending: the original delta
+//     algorithm, modified to exclude pinned IDs and hidden rows
+//     from its input set. Pinned IDs are excluded so they don't
+//     double-count; hidden rows (is_hidden_from_trending = true)
+//     are filtered out at the feActive read so they're omitted from
+//     BOTH the snapshot fetch AND the delta ranking (one filter,
+//     two effects).
+//
+// Merge semantics: pinned first, then algorithm-ranked, total
+// LIMIT N. If pinned.length >= N, return only the first N pinned
+// (the algorithmic query doesn't run). If pinned.length +
+// algorithm.length > N, the lowest-ranked algorithmic rows drop.
+//
+// Algorithm details (unchanged from the pre-slice-C single-query
+// shape, just relocated into fetchAlgorithmicTrending):
+//   1. Fetch active fan_edit IDs (canonical gate + view-tracking-
+//      active + NOT hidden, minus pinned).
+//   2. Fetch all snapshots for those IDs in one round trip.
+//   3. Group by fan_edit_id: pick the LATEST snapshot and the
+//      most-recent snapshot ≤24h ago. INNER JOIN semantics — rows
+//      with only a latest (recently ingested, no history) are
+//      skipped.
+//   4. Order by delta DESC, limit, hydrate.
 //
 // Service-role client matches the partner-catalog convention; also
 // view_tracking_snapshots has no public SELECT policy.
@@ -760,23 +778,76 @@ export async function getTrendingFanEdits(
   limit = 12,
 ): Promise<FanEditWithTitle[]> {
   const supabase = createServiceRoleClient();
+  const pinned = await fetchPinnedTrending(supabase);
+  if (pinned.length >= limit) {
+    return pinned.slice(0, limit);
+  }
+  const remaining = limit - pinned.length;
+  const pinnedIds = new Set(pinned.map((p) => p.id));
+  const algorithmic = await fetchAlgorithmicTrending(
+    supabase,
+    pinnedIds,
+    remaining,
+  );
+  return [...pinned, ...algorithmic];
+}
 
-  // 1. Active, undeleted, verified fan_edits with the standard
-  //    filters used by getRecentFanEdits. The view-tracking-status
-  //    filter is critical — deleted/private/dead rows aren't
-  //    trending material.
+// Pinned rows for Trending. Bypasses snapshot-coverage entirely —
+// the algorithmic path's inner-join requirement (latest + ≥24h ago
+// snapshots) is skipped here so admins can pin freshly-imported
+// fan_edits and they'll surface on Trending immediately.
+//
+// view_tracking_status='active' is preserved on the pinned query
+// even though pin bypasses snapshot-coverage. Snapshot-coverage is a
+// data-availability filter; view_tracking_status='active' is a
+// content-viability filter (deleted_from_platform / private rows
+// would render as broken embeds). Pin overrides the former, not the
+// latter.
+async function fetchPinnedTrending(
+  supabase: ReturnType<typeof createServiceRoleClient>,
+): Promise<FanEditWithTitle[]> {
+  const { data: pinnedRows } = await supabase
+    .from("fan_edits")
+    .select("id, trending_pin_order")
+    .eq("is_active", true)
+    .in("verification_status", PUBLICLY_READABLE_FAN_EDIT_STATUSES)
+    .eq("view_tracking_status", "active")
+    .is("deleted_at", null)
+    .eq("is_hidden_from_trending", false)
+    .not("trending_pin_order", "is", null)
+    .order("trending_pin_order", { ascending: true });
+  const ids = (pinnedRows ?? []).map((r) => r.id as string);
+  return hydrateFanEditsForTrending(supabase, ids);
+}
+
+// Algorithmic Trending — original pre-slice-C body, modified to
+// exclude pinned IDs (avoid double-count in the merge) and to
+// exclude hidden rows from the algorithm's input set.
+async function fetchAlgorithmicTrending(
+  supabase: ReturnType<typeof createServiceRoleClient>,
+  pinnedIds: Set<string>,
+  limit: number,
+): Promise<FanEditWithTitle[]> {
+  if (limit <= 0) return [];
+
+  // 1. Active, undeleted, verified, view-tracking-active fan_edits
+  //    that aren't hidden — same standard filters as before, plus
+  //    the new is_hidden_from_trending=false guard. Pinned IDs are
+  //    filtered out client-side after the fetch.
   const { data: feActive } = await supabase
     .from("fan_edits")
     .select("id")
     .eq("is_active", true)
     .in("verification_status", PUBLICLY_READABLE_FAN_EDIT_STATUSES)
     .eq("view_tracking_status", "active")
-    .is("deleted_at", null);
-  const activeIds = (feActive ?? []).map((r) => r.id as string);
+    .is("deleted_at", null)
+    .eq("is_hidden_from_trending", false);
+  const activeIds = (feActive ?? [])
+    .map((r) => r.id as string)
+    .filter((id) => !pinnedIds.has(id));
   if (activeIds.length === 0) return [];
 
-  // 2. All snapshots for those fan_edits, oldest first so we can
-  //    walk the array and "last wins" for the latest pointer.
+  // 2. All snapshots for the candidate set, oldest first.
   const { data: allSnaps } = await supabase
     .from("view_tracking_snapshots")
     .select("fan_edit_id, view_count, captured_at")
@@ -810,30 +881,38 @@ export async function getTrendingFanEdits(
   const topIds = ranked.slice(0, limit).map((r) => r.id);
   if (topIds.length === 0) return [];
 
-  // 4. Hydrate to FanEditWithTitle shape — same JOIN pattern as
-  //    getRecentFanEdits. Service-role bypasses fan_edits and
-  //    titles RLS; both have public SELECT policies anyway but
-  //    we stay on service-role for consistency with this function's
-  //    snapshot read.
+  return hydrateFanEditsForTrending(supabase, topIds);
+}
+
+// Shared hydrate helper for both Trending paths — turns an ordered
+// list of fan_edit IDs into FanEditWithTitle rows in the same order.
+// Drops rows whose title isn't active or has no poster (the carousel
+// renders posters).
+async function hydrateFanEditsForTrending(
+  supabase: ReturnType<typeof createServiceRoleClient>,
+  ids: string[],
+): Promise<FanEditWithTitle[]> {
+  if (ids.length === 0) return [];
+
   const { data: hydrated } = await supabase
     .from("fan_edits")
     .select(
       "id, title_id, platform, embed_url, thumbnail_url, creator_handle_displayed, creator_id, created_at, titles!inner(slug, title, poster_url, is_active)",
     )
-    .in("id", topIds)
+    .in("id", ids)
     .eq("titles.is_active", true);
   const rowsRaw = (hydrated ?? []) as unknown as FanEditJoinRow[];
   const rows = rowsRaw.filter((r) => r.titles && r.titles.poster_url);
 
-  // Preserve the delta-ranked order (hydrate query loses it).
-  const orderIndex = new Map(topIds.map((id, i) => [id, i]));
+  // Preserve the input order (hydrate query loses it).
+  const orderIndex = new Map(ids.map((id, i) => [id, i]));
   rows.sort(
     (a, b) =>
       (orderIndex.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
       (orderIndex.get(b.id) ?? Number.MAX_SAFE_INTEGER),
   );
 
-  // Creator handle map (mirrors getRecentFanEdits).
+  // Creator handle map — same pattern as getRecentFanEdits.
   const creatorIds = Array.from(
     new Set(rows.map((r) => r.creator_id).filter((id): id is string => !!id)),
   );

--- a/supabase/migrations/20260526000003_fan_edits_trending_curation.sql
+++ b/supabase/migrations/20260526000003_fan_edits_trending_curation.sql
@@ -1,0 +1,51 @@
+-- Add per-fan_edit columns for super-admin curation of the homepage
+-- Trending Edits carousel. Today the carousel uses a 24h view-count
+-- delta algorithm with inner-join semantics — a fan_edit must have
+-- BOTH a "latest" snapshot AND a "≥24h ago" snapshot to be ranked,
+-- so rows lacking history are excluded. This migration leaves all
+-- rows with no curation overrides on rollout (trending_pin_order
+-- NULL on every row, is_hidden_from_trending FALSE). The
+-- /admin/trending-edits page (shipping in the same commit) is the
+-- first surface that mutates these columns.
+--
+-- Defaults & invariants:
+--   - trending_pin_order INTEGER NULL — pinned position; NULL = not
+--     pinned; smaller numbers = higher pin position. The homepage
+--     query renders pinned rows first (ORDER BY trending_pin_order
+--     ASC), then the remaining slots fill from the algorithmic
+--     delta ranking. The 12-row LIMIT applies after the merge.
+--   - PIN BYPASSES SNAPSHOT-COVERAGE — this is the
+--     algorithmically-tricky bit for Slice C. Pinned rows are
+--     fetched via a separate query that does NOT impose the
+--     latest+≥24h-ago snapshot requirement, so an admin can pin a
+--     freshly-imported fan_edit (no view-tracking history yet) and
+--     it will surface on Trending. The pinned query still honors
+--     the canonical three-clause gate AND view_tracking_status =
+--     'active' (so deleted_from_platform / private rows do not
+--     render as broken embeds), but it ignores the two-endpoint
+--     snapshot window the delta algorithm requires.
+--   - is_hidden_from_trending BOOLEAN NOT NULL DEFAULT FALSE —
+--     excludes a fan_edit from the Trending Edits carousel ONLY.
+--     Per-carousel hide, not a global hide: a fan_edit can stay on
+--     Recent / Featured surfaces while being hidden from Trending.
+--   - The hidden filter feeds the algorithm's input set. Adding
+--     `AND is_hidden_from_trending = false` to the algorithmic
+--     query's feActive read excludes hidden rows from BOTH the
+--     snapshot read AND the delta ranking — one filter, two
+--     effects.
+--   - No index. The Trending homepage query selects a top-12 set;
+--     the pinned subset stays tiny in practice (1-5 rows).
+--   - Per-carousel naming completes the "recent_/allfilms_/trending_"
+--     prefix family — see 20260526000001 (recent) and
+--     20260526000002 (allfilms). The three carousels with
+--     algorithmic / recency / catalog ordering each carry their own
+--     pin + hide columns with parallel naming.
+--
+-- Mirrors 20260526000001 (fan_edits_recent_curation) — same column
+-- shape on the same table; semantically distinct (Recent is a pure
+-- recency carousel, Trending is algorithmic with a snapshot-coverage
+-- inner-join that the pin path must sidestep).
+
+alter table public.fan_edits
+  add column if not exists trending_pin_order integer,
+  add column if not exists is_hidden_from_trending boolean not null default false;


### PR DESCRIPTION
The algorithmically-tricky carousel — pin overrides the 24h-delta ranking AND bypasses its inner-join snapshot-coverage requirement. Completes the homepage curation track for all five carousels (slice D is lateral section order).

## What ships

**Migration `20260526000003_fan_edits_trending_curation.sql`** (already applied to prod):
- `fan_edits.trending_pin_order` (INT NULL)
- `fan_edits.is_hidden_from_trending` (BOOL NOT NULL DEFAULT FALSE)

Completes the `recent_/allfilms_/trending_` per-carousel column-prefix family.

**`getTrendingFanEdits` restructure:** one query → three functions.
- `fetchPinnedTrending` — direct fetch by `trending_pin_order NOT NULL`, bypasses snapshot-coverage.
- `fetchAlgorithmicTrending` — the original delta algorithm, modified to filter hidden rows from `feActive` (one filter, two effects) and pinned IDs from the candidate set.
- Merge: pinned first, then algorithm-ranked, total LIMIT N.

`view_tracking_status='active'` preserved on the pinned path so deleted-from-platform / private rows can't render as broken embeds. Pin overrides snapshot-coverage, not content-viability.

**`/admin/trending-edits` curator** mirrors RecentEditsCurator's three-section shape with explanatory copy about pin-bypasses-snapshot-coverage.

**`/api/admin/fan-edits/trending/reorder` API** mirrors recent/reorder with the extra view_tracking_status clause on the canonical-gate backstop.

**`/admin/homepage` hub:** Trending Edits flips from "coming soon" to live. All five carousels now have admin curation.

## Scope

6 files (+1101, −38). `npm run build` clean. No changes to slices A or B's surfaces; the algorithmic merge is self-contained inside `getTrendingFanEdits`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)