### PR TITLE
homepage curation slice D: lateral section order

### DIFF
--- a/src/app/admin/homepage/HomepageSectionsReorder.tsx
+++ b/src/app/admin/homepage/HomepageSectionsReorder.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+// Drag-to-reorder UI for the lateral order of homepage carousels.
+// Lives at the top of /admin/homepage, ABOVE the existing curator
+// card list. Saves immediately on drop via POST /api/admin/homepage/
+// sections/reorder; mirrors FeaturedCurator's dnd-kit pattern.
+//
+// This component manages ORDER only — section-level visibility
+// (hiding an entire carousel) is out of slice D's scope.
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  fetchJson,
+  FetchJsonError,
+  RateLimitedError,
+} from "@/lib/fetch-json";
+import {
+  HOMEPAGE_SECTION_LABELS,
+  type HomepageSectionSlug,
+} from "@/lib/homepage-sections";
+
+type Props = {
+  initialOrder: HomepageSectionSlug[];
+};
+
+export default function HomepageSectionsReorder({ initialOrder }: Props) {
+  const router = useRouter();
+  const [order, setOrder] = useState<HomepageSectionSlug[]>(initialOrder);
+  const [saving, setSaving] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  );
+
+  async function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = order.findIndex((s) => s === active.id);
+    const newIndex = order.findIndex((s) => s === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+    const prev = order;
+    const next = arrayMove(order, oldIndex, newIndex);
+    setOrder(next);
+    setSaving(true);
+    setErrorMsg(null);
+    try {
+      await fetchJson("/api/admin/homepage/sections/reorder", {
+        method: "POST",
+        body: { order: next },
+      });
+      router.refresh();
+    } catch (err) {
+      setErrorMsg(
+        err instanceof RateLimitedError || err instanceof FetchJsonError
+          ? err.userMessage
+          : err instanceof Error
+            ? err.message
+            : String(err),
+      );
+      setOrder(prev);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-display-sm m-0">Section order</h2>
+        <p className="m-0 text-body-sm text-moonbeem-ink-muted">
+          Drag to reorder the homepage&apos;s vertical layout. Changes
+          take effect on the next homepage visit. Per-row pin and
+          hide inside each section is curated below.
+        </p>
+      </div>
+      {errorMsg && (
+        <p className="text-body-sm text-moonbeem-magenta">{errorMsg}</p>
+      )}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={order}
+          strategy={verticalListSortingStrategy}
+        >
+          <ul
+            className={`flex flex-col gap-2 ${saving ? "opacity-70" : ""}`}
+            aria-busy={saving}
+          >
+            {order.map((slug, idx) => (
+              <SortableSectionRow
+                key={slug}
+                slug={slug}
+                position={idx + 1}
+              />
+            ))}
+          </ul>
+        </SortableContext>
+      </DndContext>
+    </section>
+  );
+}
+
+function SortableSectionRow({
+  slug,
+  position,
+}: {
+  slug: HomepageSectionSlug;
+  position: number;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: slug });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 20 : undefined,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-3 rounded-md border bg-white/[0.02] px-3 py-2 ${
+        isDragging
+          ? "border-moonbeem-pink shadow-[0_8px_24px_rgba(245,197,225,0.25)]"
+          : "border-white/10"
+      }`}
+    >
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        aria-label={`Drag ${HOMEPAGE_SECTION_LABELS[slug]} to reorder`}
+        className="cursor-grab touch-none px-1 text-moonbeem-ink-subtle hover:text-moonbeem-ink"
+      >
+        ⋮⋮
+      </button>
+      <span className="w-6 shrink-0 text-right font-mono text-body-sm text-moonbeem-ink-subtle tabular-nums">
+        {position}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-body-sm text-moonbeem-ink">
+          {HOMEPAGE_SECTION_LABELS[slug]}
+        </div>
+        <div className="truncate font-mono text-caption text-moonbeem-ink-subtle">
+          {slug}
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/src/app/admin/homepage/page.tsx
+++ b/src/app/admin/homepage/page.tsx
@@ -1,12 +1,20 @@
-// /admin/homepage — hub linking the five curators that shape the
-// homepage. Two already exist (Marquee, Featured); one ships in this
-// commit (Recent Edits); two are scoped for follow-ups (All Films,
-// Trending Edits). Disabled placeholder rows show the eventual full
-// shape so an admin scanning the page understands what's coming.
+// /admin/homepage — hub for every homepage curation surface. Two
+// distinct functions on one page:
+//
+//   1. SECTION ORDER (slice D, top of the page) — drag-to-reorder
+//      the vertical layout of the five carousels. Saves immediately
+//      via POST /api/admin/homepage/sections/reorder.
+//
+//   2. PER-SECTION CURATION (slices A/B/C/featured/marquee, below)
+//      — entry-point cards that link to each section's own curator
+//      (/admin/marquee, /admin/featured, /admin/recent-edits,
+//      /admin/all-films, /admin/trending-edits).
 
 import type { Metadata } from "next";
 import Link from "next/link";
 import { requireSuperAdminOr404 } from "@/lib/dal";
+import { getHomepageSectionOrder } from "@/lib/homepage-sections";
+import HomepageSectionsReorder from "./HomepageSectionsReorder";
 
 export const metadata: Metadata = {
   title: "Homepage curation · Moonbeem admin",
@@ -56,6 +64,7 @@ const ENTRIES: CuratorEntry[] = [
 
 export default async function AdminHomepagePage() {
   await requireSuperAdminOr404();
+  const initialOrder = await getHomepageSectionOrder();
   return (
     <div className="min-h-screen px-6 py-12 text-moonbeem-ink">
       <div className="mx-auto flex max-w-3xl flex-col gap-8">
@@ -71,11 +80,20 @@ export default async function AdminHomepagePage() {
           </Link>
         </div>
         <p className="text-body text-moonbeem-ink-muted m-0">
-          Curate every section of the homepage from one place. Each
-          carousel has its own pin / hide controls — pins float to the
-          top of the section, hidden items drop out of the section only
-          (other carousels still surface them).
+          Curate every section of the homepage from one place. Reorder
+          the section layout above; click into a section card below to
+          curate its contents (pins float to the top of that section;
+          hidden items drop out of that section only).
         </p>
+        <HomepageSectionsReorder initialOrder={initialOrder} />
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <h2 className="text-display-sm m-0">Section contents</h2>
+            <p className="m-0 text-body-sm text-moonbeem-ink-muted">
+              Per-section pin and hide controls.
+            </p>
+          </div>
+        </div>
         <ul className="flex flex-col gap-3">
           {ENTRIES.map((e) =>
             e.href ? (

--- a/src/app/api/admin/homepage/sections/reorder/route.ts
+++ b/src/app/api/admin/homepage/sections/reorder/route.ts
@@ -1,0 +1,109 @@
+// POST /api/admin/homepage/sections/reorder — super-admin lateral
+// order of the homepage carousel sections. Mechanical clone of
+// /api/admin/fan-edits/recent/reorder shape, simplified because the
+// homepage_sections taxonomy is a fixed five-slug set (no pinned /
+// hidden distinction, no per-entity backstop — the slug CHECK
+// constraint locks the known set at the schema layer).
+//
+// Body shape:
+//   { order: HomepageSectionSlug[] }   // exactly N slugs, no dups
+//
+// Two-phase write (TEMP_OFFSET=10_000) keeps the update collision-
+// free and future-proofs a potential UNIQUE on display_order.
+// revalidatePath("/") on success.
+
+import { NextResponse, type NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { requireSuperAdmin } from "@/lib/dal";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import { enforce } from "@/lib/ratelimit";
+import {
+  HOMEPAGE_SECTION_SLUGS,
+  type HomepageSectionSlug,
+} from "@/lib/homepage-sections";
+
+const TEMP_OFFSET = 10_000;
+
+export async function POST(request: NextRequest) {
+  const session = await requireSuperAdmin();
+  const limit = await enforce(
+    "admin",
+    session.userId,
+    "admin/homepage/sections/reorder",
+  );
+  if (!limit.ok) return limit.response;
+
+  let body: { order?: unknown };
+  try {
+    body = (await request.json()) as { order?: unknown };
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const rawOrder = Array.isArray(body.order) ? body.order : null;
+  if (!rawOrder) {
+    return NextResponse.json({ error: "invalid_order" }, { status: 400 });
+  }
+  if (rawOrder.length !== HOMEPAGE_SECTION_SLUGS.length) {
+    return NextResponse.json(
+      {
+        error: "wrong_count",
+        expected: HOMEPAGE_SECTION_SLUGS.length,
+        got: rawOrder.length,
+      },
+      { status: 400 },
+    );
+  }
+
+  const knownSlugs = new Set<string>(HOMEPAGE_SECTION_SLUGS);
+  const seen = new Set<string>();
+  const order: HomepageSectionSlug[] = [];
+  for (const v of rawOrder) {
+    if (typeof v !== "string") {
+      return NextResponse.json(
+        { error: "invalid_slug_type" },
+        { status: 400 },
+      );
+    }
+    if (!knownSlugs.has(v)) {
+      return NextResponse.json(
+        { error: "unknown_slug", slug: v },
+        { status: 400 },
+      );
+    }
+    if (seen.has(v)) {
+      return NextResponse.json(
+        { error: "duplicate_slug", slug: v },
+        { status: 400 },
+      );
+    }
+    seen.add(v);
+    order.push(v as HomepageSectionSlug);
+  }
+
+  const supabase = createServiceRoleClient();
+
+  // Two-phase write — bump every row to a high temporary range so
+  // the final write can collide-free assign 1..N.
+  for (let i = 0; i < order.length; i++) {
+    const { error } = await supabase
+      .from("homepage_sections")
+      .update({ display_order: TEMP_OFFSET + i })
+      .eq("slug", order[i]);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  }
+  for (let i = 0; i < order.length; i++) {
+    const { error } = await supabase
+      .from("homepage_sections")
+      .update({ display_order: i + 1 })
+      .eq("slug", order[i]);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  }
+
+  revalidatePath("/");
+  return NextResponse.json({ success: true });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,18 +5,65 @@ import {
   getTrendingFanEdits,
 } from "@/lib/queries/titles";
 import { getMarqueePartners } from "@/lib/queries/partners";
+import {
+  getHomepageSectionOrder,
+  type HomepageSectionSlug,
+} from "@/lib/homepage-sections";
 import TitleCarousel from "@/components/TitleCarousel";
 import FanEditCarousel from "@/components/FanEditCarousel";
 import PartnerLogoStrip from "@/components/PartnerLogoStrip";
 
 export default async function Home() {
-  const [featured, recentFanEdits, partners, allFilms, trending] = await Promise.all([
-    getFeaturedTitles(),
-    getRecentFanEdits(12),
-    getMarqueePartners(),
-    getAllFilms(),
-    getTrendingFanEdits(12),
-  ]);
+  // Fetch every section's data + the configured section order in
+  // parallel. Each carousel is a separate query (already the case
+  // pre-slice-D); we just add one more for the order config.
+  const [order, featured, recentFanEdits, partners, allFilms, trending] =
+    await Promise.all([
+      getHomepageSectionOrder(),
+      getFeaturedTitles(),
+      getRecentFanEdits(12),
+      getMarqueePartners(),
+      getAllFilms(),
+      getTrendingFanEdits(12),
+    ]);
+
+  // Renderer-per-slug — keeps the conditional length>0 guard
+  // co-located with each section. Returning null means "the section
+  // is configured but has no data" — it drops out of the rendered
+  // layout entirely (and out of the last-section bottom-padding
+  // calculation below).
+  const renderers: Record<HomepageSectionSlug, () => React.ReactNode> = {
+    marquee: () => <PartnerLogoStrip partners={partners} />,
+    featured: () => (
+      <TitleCarousel title="Featured Films" titles={featured} />
+    ),
+    trending: () =>
+      trending.length > 0 ? (
+        <FanEditCarousel title="Trending Edits" fanEdits={trending} />
+      ) : null,
+    recent: () =>
+      recentFanEdits.length > 0 ? (
+        <FanEditCarousel title="Recent Edits" fanEdits={recentFanEdits} />
+      ) : null,
+    "all-films": () =>
+      allFilms.length > 0 ? (
+        <TitleCarousel title="All Films" titles={allFilms} />
+      ) : null,
+  };
+
+  // Compute each section's rendered node ONCE, then determine the
+  // index of the last visibly-rendered section so we can apply the
+  // larger bottom padding (pb-20) there instead of pb-10. This used
+  // to be hardcoded to "All Films" pre-slice-D; under arbitrary
+  // reorder it's whichever section ends up rendered last.
+  const rendered: Array<{ slug: HomepageSectionSlug; node: React.ReactNode }> =
+    order.map((slug) => ({ slug, node: renderers[slug]() }));
+  const visibleIndexes = rendered
+    .map((r, i) => (r.node ? i : -1))
+    .filter((i) => i >= 0);
+  const lastVisibleIndex = visibleIndexes.length > 0
+    ? visibleIndexes[visibleIndexes.length - 1]
+    : -1;
 
   return (
     <div className="relative flex flex-col items-stretch flex-1">
@@ -31,31 +78,24 @@ export default async function Home() {
         </h1>
       </div>
 
-      <div className="w-full pb-6">
-        <PartnerLogoStrip partners={partners} />
-      </div>
-
-      <div className="w-full pb-10">
-        <TitleCarousel title="Featured Films" titles={featured} />
-      </div>
-
-      {trending.length > 0 && (
-        <div className="w-full pb-10">
-          <FanEditCarousel title="Trending Edits" fanEdits={trending} />
-        </div>
-      )}
-
-      {recentFanEdits.length > 0 && (
-        <div className="w-full pb-10">
-          <FanEditCarousel title="Recent Edits" fanEdits={recentFanEdits} />
-        </div>
-      )}
-
-      {allFilms.length > 0 && (
-        <div className="w-full pb-20">
-          <TitleCarousel title="All Films" titles={allFilms} />
-        </div>
-      )}
+      {rendered.map((r, i) => {
+        if (!r.node) return null;
+        const isLast = i === lastVisibleIndex;
+        // Marquee has its own visual rhythm — pre-slice-D it used
+        // pb-6 (logo strip is lighter visually than a poster carousel
+        // and doesn't need the same gap below). Preserve that here.
+        const className =
+          r.slug === "marquee" && !isLast
+            ? "w-full pb-6"
+            : isLast
+              ? "w-full pb-20"
+              : "w-full pb-10";
+        return (
+          <div key={r.slug} className={className}>
+            {r.node}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/lib/homepage-sections.ts
+++ b/src/lib/homepage-sections.ts
@@ -1,0 +1,95 @@
+// Source of truth for the homepage's orderable carousel sections.
+// The 'moonbeem.' wordmark at the top of the page is a fixed header
+// and is NOT one of these sections.
+//
+// Per-row pin / hide curation (slices A/B/C) lives on the entity
+// tables (titles.allfilms_pin_order, fan_edits.recent_pin_order /
+// trending_pin_order, plus the matching is_hidden_from_* flags).
+// This module is strictly about the vertical order of the sections
+// themselves.
+//
+// Reads the homepage_sections table (slug PK + display_order ASC).
+// Falls back to DEFAULT_HOMEPAGE_SECTION_ORDER if the DB returns
+// empty or fewer rows than expected, so a mid-migration race or a
+// hand-deleted row can't blank the homepage.
+
+import { createServiceRoleClient } from "@/lib/supabase/service";
+
+export const HOMEPAGE_SECTION_SLUGS = [
+  "marquee",
+  "featured",
+  "trending",
+  "recent",
+  "all-films",
+] as const;
+
+export type HomepageSectionSlug = (typeof HOMEPAGE_SECTION_SLUGS)[number];
+
+export const HOMEPAGE_SECTION_LABELS: Record<HomepageSectionSlug, string> = {
+  marquee: "Partners (marquee)",
+  featured: "Featured Films",
+  trending: "Trending Edits",
+  recent: "Recent Edits",
+  "all-films": "All Films",
+};
+
+// Default order matches today's hardcoded JSX in src/app/page.tsx.
+// Used as the fallback when the DB returns empty / partial state and
+// as the seed value in the migration.
+export const DEFAULT_HOMEPAGE_SECTION_ORDER: HomepageSectionSlug[] = [
+  "marquee",
+  "featured",
+  "trending",
+  "recent",
+  "all-films",
+];
+
+const KNOWN_SLUGS = new Set<string>(HOMEPAGE_SECTION_SLUGS);
+
+function isHomepageSectionSlug(s: string): s is HomepageSectionSlug {
+  return KNOWN_SLUGS.has(s);
+}
+
+// Returns the configured section order, top-to-bottom. Defensive on
+// the read side:
+//   - DB error → log + fall back to DEFAULT.
+//   - Empty result → fall back to DEFAULT.
+//   - Unknown slug in the result → drop it (CHECK constraint should
+//     prevent this, but a constraint extension mid-deploy could
+//     transiently allow new slugs the code doesn't render yet).
+//   - Missing slug in the result → append in DEFAULT order at the
+//     end so the section still renders.
+export async function getHomepageSectionOrder(): Promise<HomepageSectionSlug[]> {
+  const supabase = createServiceRoleClient();
+  const { data, error } = await supabase
+    .from("homepage_sections")
+    .select("slug, display_order")
+    .order("display_order", { ascending: true });
+  if (error) {
+    console.error(
+      `[homepage-sections] read failed; falling back to default order: ${error.message}`,
+    );
+    return [...DEFAULT_HOMEPAGE_SECTION_ORDER];
+  }
+
+  const fromDb: HomepageSectionSlug[] = [];
+  const seen = new Set<HomepageSectionSlug>();
+  for (const r of data ?? []) {
+    const slug = String(r.slug);
+    if (!isHomepageSectionSlug(slug)) continue;
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    fromDb.push(slug);
+  }
+
+  if (fromDb.length === 0) {
+    return [...DEFAULT_HOMEPAGE_SECTION_ORDER];
+  }
+
+  // Append any missing-from-DB slugs at the end in DEFAULT order, so
+  // a newly-added section that doesn't yet have a row still renders.
+  const missing = DEFAULT_HOMEPAGE_SECTION_ORDER.filter(
+    (s) => !seen.has(s),
+  );
+  return [...fromDb, ...missing];
+}

--- a/supabase/migrations/20260526000004_homepage_sections.sql
+++ b/supabase/migrations/20260526000004_homepage_sections.sql
@@ -1,0 +1,68 @@
+-- Lateral order of homepage carousel sections. One row per
+-- orderable section (marquee, featured, trending, recent, all-films).
+-- The homepage reads display_order ASC and renders sections in that
+-- order; slice-A/B/C's per-row pin/hide overrides continue to apply
+-- INSIDE each section unchanged.
+--
+-- The 'moonbeem.' wordmark at the top of the page is a fixed header,
+-- not a section here. Only the five carousels below it are reorderable.
+--
+-- Defaults & invariants:
+--   - slug TEXT PRIMARY KEY — small, queryable, easier to inspect
+--     than a uuid for an admin-facing config table with five known
+--     rows.
+--   - display_order INTEGER NOT NULL — ASC sort key. No UNIQUE on
+--     display_order today; the reorder API does a two-phase write
+--     (TEMP_OFFSET=10_000) so a future UNIQUE addition lands
+--     collision-free.
+--   - slug CHECK constraint locks the known taxonomy. A future
+--     section addition (or rename) is a DROP-then-ADD constraint
+--     change, matching the campaigns_v1_schema / campaign_funding
+--     supersede precedent.
+--   - Seeded in today's hardcoded JSX order. ON CONFLICT keeps the
+--     migration idempotent on re-apply.
+--   - No "is_visible" or hide column. Section-level visibility
+--     (turning off an entire carousel) is out of slice D's scope.
+--     If added later, an `is_visible boolean DEFAULT true` column
+--     drops in without breaking the existing per-section pin/hide
+--     story.
+--   - RLS enabled, no policies. Service-role-only writes via the
+--     admin reorder API; reads go through the service-role client
+--     in the homepage page.tsx (matches partners / titles /
+--     campaign-* read conventions).
+--
+-- Mirrors the column-naming family used by the per-row curation
+-- migrations (20260512000007 featured, 20260512000008 marquee,
+-- 20260526000001 recent, 20260526000002 allfilms, 20260526000003
+-- trending) — a small table with display_order as the sort key
+-- plus a CHECK that locks the taxonomy.
+
+create table if not exists public.homepage_sections (
+  slug text primary key,
+  display_order integer not null,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.homepage_sections
+  drop constraint if exists homepage_sections_slug_check;
+
+alter table public.homepage_sections
+  add constraint homepage_sections_slug_check
+  check (slug in ('marquee', 'featured', 'trending', 'recent', 'all-films'));
+
+insert into public.homepage_sections (slug, display_order) values
+  ('marquee',    1),
+  ('featured',   2),
+  ('trending',   3),
+  ('recent',     4),
+  ('all-films',  5)
+on conflict (slug) do nothing;
+
+alter table public.homepage_sections enable row level security;
+-- No policies. Service-role only.
+
+drop trigger if exists set_updated_at_homepage_sections
+  on public.homepage_sections;
+create trigger set_updated_at_homepage_sections
+  before update on public.homepage_sections
+  for each row execute function public.set_updated_at();


### PR DESCRIPTION
Final slice of the homepage curation track. Drag-to-reorder the lateral order of the five carousels (Marquee / Featured / Trending / Recent / All Films) from `/admin/homepage`.

## What ships

**Migration `20260526000004_homepage_sections.sql`** (already applied to prod):
- `homepage_sections` table — slug PK + display_order + updated_at
- CHECK constraint locks the five-slug taxonomy
- Seeded in today's hardcoded order
- RLS enabled, no policies (service-role only)

**`src/lib/homepage-sections.ts`** — shared source of truth: slug constants, labels, default order, `getHomepageSectionOrder()` query with defensive fallbacks.

**`src/app/page.tsx`** refactored from hardcoded JSX to renderer-map pattern. `lastVisibleIndex` computed in one pass so `pb-20` lands on whichever section ends up last under reorder. Marquee preserves its pre-slice-D `pb-6` rhythm when it isn't the last visible section.

**`/admin/homepage` page** gains a "Section order" block above the existing curator card list. New `HomepageSectionsReorder` client component mirrors the dnd-kit shape used by `FeaturedCurator` / `RecentEditsCurator`.

**`/api/admin/homepage/sections/reorder` API** uses the two-phase write pattern. Validates wrong count, unknown slugs, duplicates. `revalidatePath('/')` on success.

## What this closes

The homepage curation track is structurally complete:
- Per-row pin+hide on all five carousels (slices A/B/C/featured/marquee)
- Lateral order drag-controllable (this slice)
- All five surfaces consolidated under `/admin/homepage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)