### PR TITLE
partner remix approval: admin approve/reject on partner-scoped submissions

### DIFF
--- a/src/app/api/admin/fan-edits/[id]/approve/route.ts
+++ b/src/app/api/admin/fan-edits/[id]/approve/route.ts
@@ -44,7 +44,14 @@ export async function POST(
 
   const { error: updateErr } = await sb
     .from("fan_edits")
-    .update({ verification_status: "approved" })
+    .update({
+      verification_status: "approved",
+      // Audit columns added by 20260526000005. Same columns are
+      // populated by the partner-decide path so all three routes
+      // produce a consistent audit trail going forward.
+      decided_by_user_id: session.userId,
+      decided_at: new Date().toISOString(),
+    })
     .eq("id", id);
   if (updateErr) {
     return NextResponse.json({ error: updateErr.message }, { status: 500 });

--- a/src/app/api/admin/fan-edits/[id]/reject/route.ts
+++ b/src/app/api/admin/fan-edits/[id]/reject/route.ts
@@ -67,6 +67,11 @@ export async function POST(
     .update({
       verification_status: "rejected",
       rejection_reason: reason,
+      // Audit columns added by 20260526000005. Same columns are
+      // populated by the partner-decide path so all three routes
+      // produce a consistent audit trail going forward.
+      decided_by_user_id: session.userId,
+      decided_at: new Date().toISOString(),
     })
     .eq("id", id);
   if (updateErr) {

--- a/src/app/api/p/[slug]/fan-edits/[id]/decide/route.ts
+++ b/src/app/api/p/[slug]/fan-edits/[id]/decide/route.ts
@@ -1,0 +1,258 @@
+// Partner-admin endpoint for approving or rejecting a fan_edit
+// submitted to one of the partner's titles. Same approval authority
+// as super-admins, scoped to fan_edits whose title.partner_id
+// matches a partner_users membership for the acting user.
+//
+// POST /api/p/[slug]/fan-edits/[id]/decide
+// Body: { decision: 'approved' | 'rejected', reason?: string }
+//
+// Auth (mirrors /api/p/[slug]/campaigns/route.ts):
+//   - getUser → 401 if unauthenticated.
+//   - enforce("partnerWrites", ...) rate limit.
+//   - SELECT partner by slug → 404.
+//   - super_admin bypass via getCurrentProfile.role.
+//   - Otherwise: partner_users membership with role='admin' required.
+//     Viewer-role gets 403.
+//   - fan_edit MUST belong to a title with this partner_id. NULL or
+//     mismatch → 403 (the fan_edit isn't this partner's to decide).
+//
+// Asymmetry vs super-admin reject (intentional, per spec):
+//   - APPROVE: fires fulfillTitleRequestsForFanEdit AND sends
+//     fan_edit_approved email via after(). Same behavior as the
+//     super-admin path — approval is approval regardless of who
+//     pressed the button.
+//   - REJECT: DOES NOT send any creator email. Partner rejection is
+//     not platform moderation; the creator-facing notification UX
+//     for "your edit was rejected" is the super-admin path's
+//     responsibility (the super-admin route REQUIRES a reason so it
+//     can render it in the email). Partner rejection is an
+//     editorial decision by the partner; reason is optional and
+//     written for audit only, not sent to anyone.
+//
+// Audit: decided_by_user_id + decided_at populated in the same
+// UPDATE. The super-admin approve + reject routes were updated in
+// this same slice to write the audit columns too, so all three
+// paths produce a consistent audit trail going forward.
+
+import { NextResponse, after, type NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { getCurrentProfile, getUser } from "@/lib/dal";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import { enforce } from "@/lib/ratelimit";
+import { fulfillTitleRequestsForFanEdit } from "@/lib/title-requests/fulfill-on-fan-edit";
+import { sendFanEditApproved } from "@/lib/email/fan-edit";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const REASON_MAX = 500;
+
+type Body = { decision?: string; reason?: string };
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string; id: string }> },
+) {
+  const user = await getUser();
+  if (!user) {
+    return NextResponse.json({ error: "not_authenticated" }, { status: 401 });
+  }
+  const limit = await enforce(
+    "partnerWrites",
+    user.id,
+    "p/fan-edits/decide",
+  );
+  if (!limit.ok) return limit.response;
+
+  const { slug, id } = await params;
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json({ error: "invalid_id" }, { status: 400 });
+  }
+
+  const supabase = createServiceRoleClient();
+
+  const { data: partner } = await supabase
+    .from("partners")
+    .select("id")
+    .eq("slug", slug)
+    .maybeSingle();
+  if (!partner) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  // super_admin bypass; otherwise partner_users.role='admin' required.
+  const profile = await getCurrentProfile();
+  if (profile?.role !== "super_admin") {
+    const { data: membership } = await supabase
+      .from("partner_users")
+      .select("role")
+      .eq("partner_id", partner.id)
+      .eq("user_id", user.id)
+      .is("deleted_at", null)
+      .maybeSingle();
+    if (!membership || membership.role !== "admin") {
+      return NextResponse.json({ error: "not_authorized" }, { status: 403 });
+    }
+  }
+
+  // Validate body.
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  const decision = body.decision;
+  if (decision !== "approved" && decision !== "rejected") {
+    return NextResponse.json({ error: "invalid_decision" }, { status: 400 });
+  }
+  // Reason is partner-internal audit only; only meaningful on reject.
+  // Ignored on approve, validated on reject.
+  let reason: string | null = null;
+  if (decision === "rejected" && typeof body.reason === "string") {
+    const r = body.reason.trim();
+    if (r.length > REASON_MAX) {
+      return NextResponse.json(
+        { error: `reason too long (max ${REASON_MAX} chars)` },
+        { status: 400 },
+      );
+    }
+    if (r.length > 0) reason = r;
+  }
+
+  // Fetch the fan_edit AND its title's partner_id in one round trip.
+  // Inner-join on titles ensures the edit's title exists; partner_id
+  // check enforces partner-scoping.
+  const { data: fanEdit, error: readErr } = await supabase
+    .from("fan_edits")
+    .select(
+      "id, title_id, created_by_user_id, verification_status, titles!inner(partner_id, slug)",
+    )
+    .eq("id", id)
+    .maybeSingle();
+  if (readErr) {
+    return NextResponse.json({ error: readErr.message }, { status: 500 });
+  }
+  if (!fanEdit) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+  const fanEditTitlePartnerId =
+    (fanEdit.titles as unknown as { partner_id: string | null; slug: string })
+      .partner_id;
+  const titleSlug =
+    (fanEdit.titles as unknown as { partner_id: string | null; slug: string })
+      .slug;
+  if (
+    fanEditTitlePartnerId === null ||
+    fanEditTitlePartnerId !== partner.id
+  ) {
+    // Edit's title belongs to a different partner (or no partner at
+    // all — TMDB-imported catalog entries with NULL partner_id are
+    // super-admin territory by definition). Same 403 the auth check
+    // would have produced if this user weren't an admin of this
+    // partner; we use a distinct error code so the client can
+    // distinguish "you don't admin this partner" from "this fan_edit
+    // isn't this partner's."
+    return NextResponse.json(
+      { error: "fan_edit_not_in_partner" },
+      { status: 403 },
+    );
+  }
+
+  if (fanEdit.verification_status !== "pending") {
+    return NextResponse.json(
+      {
+        error: `not_pending`,
+        current_status: fanEdit.verification_status,
+      },
+      { status: 409 },
+    );
+  }
+
+  // Single UPDATE: status flip + audit stamp + rejection_reason if
+  // reject path supplied one. rejection_reason explicitly nulled on
+  // approve to avoid carrying a stale reason if the fan_edit was
+  // previously rejected and somehow re-pended (defensive; the
+  // pending guard above should prevent this in practice).
+  const update: {
+    verification_status: "approved" | "rejected";
+    decided_by_user_id: string;
+    decided_at: string;
+    rejection_reason: string | null;
+  } = {
+    verification_status: decision,
+    decided_by_user_id: user.id,
+    decided_at: new Date().toISOString(),
+    rejection_reason: decision === "rejected" ? reason : null,
+  };
+
+  const { error: updateErr, data: updated } = await supabase
+    .from("fan_edits")
+    .update(update)
+    .eq("id", id)
+    .select(
+      "id, title_id, verification_status, decided_by_user_id, decided_at, rejection_reason",
+    )
+    .maybeSingle();
+  if (updateErr || !updated) {
+    return NextResponse.json(
+      { error: updateErr?.message ?? "update_failed" },
+      { status: 500 },
+    );
+  }
+
+  const titleId = fanEdit.title_id as string;
+  const createdByUserId = fanEdit.created_by_user_id as string | null;
+
+  if (decision === "approved") {
+    // Mirror the super-admin approve path: fulfill any open
+    // title_requests on this title, then email the submitter.
+    try {
+      await fulfillTitleRequestsForFanEdit(supabase, titleId, id);
+    } catch (err) {
+      console.error(
+        `[partner-decide] fulfillTitleRequestsForFanEdit failed for fan_edit=${id} title=${titleId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (createdByUserId) {
+      after(async () => {
+        try {
+          const res = await sendFanEditApproved({
+            userId: createdByUserId,
+            fanEditId: id,
+            titleId,
+          });
+          if (!res.ok) {
+            console.warn(
+              `[partner-decide] sendFanEditApproved failed for fan_edit=${id}: ${res.error}`,
+            );
+          }
+        } catch (e) {
+          console.warn(
+            `[partner-decide] sendFanEditApproved threw for fan_edit=${id}: ${e instanceof Error ? e.message : String(e)}`,
+          );
+        }
+      });
+    }
+  }
+  // decision === "rejected" intentionally has NO creator notification.
+  // Partner rejection is an editorial choice by the partner, not
+  // platform moderation. The super-admin reject path DOES email the
+  // creator (and requires a reason for the email body); the partner
+  // path leaves the creator un-notified in v1.
+
+  // Revalidate every surface that filters fan_edits through the
+  // canonical readable gate. The flipped row drops off public reads
+  // immediately (rejected) or appears on them (approved).
+  revalidatePath(`/p/${slug}/dashboard`);
+  if (titleSlug) {
+    revalidatePath(`/t/${titleSlug}`);
+  }
+  // Homepage carousels (Trending / Recent / All Films) read through
+  // the canonical gate too.
+  revalidatePath("/");
+
+  return NextResponse.json({
+    ok: true,
+    fan_edit: updated,
+  });
+}

--- a/src/app/p/[slug]/dashboard/page.tsx
+++ b/src/app/p/[slug]/dashboard/page.tsx
@@ -21,6 +21,9 @@ import GrowthChart from "@/components/p/GrowthChart";
 import AllEditsTable from "@/components/p/AllEditsTable";
 import PartnerRatesCard from "@/components/p/PartnerRatesCard";
 import CampaignsCard from "@/components/p/CampaignsCard";
+import PartnerSubmissionsSection, {
+  type PartnerSubmission,
+} from "@/components/p/PartnerSubmissionsSection";
 import TopPerformersCardClient from "@/components/p/TopPerformersCardClient";
 import InitialAvatar from "@/components/p/InitialAvatar";
 import { rankTierClass } from "@/components/p/rankTier";
@@ -1305,6 +1308,82 @@ export default async function PartnerDashboardPage({
     is_active: t.is_active,
   }));
 
+  // Pending fan_edit submissions on the partner's titles — feeds the
+  // new Submissions section below. We do NOT apply the canonical
+  // publicly-readable gate here (this queue's whole point is rows
+  // that aren't publicly readable yet, awaiting an approve/reject
+  // decision). Active + undeleted filters still apply — soft-paused
+  // / soft-deleted rows shouldn't appear in the queue.
+  const pendingByTitle = new Map<
+    string,
+    { name: string; slug: string }
+  >();
+  for (const t of titleRows) {
+    pendingByTitle.set(t.id, { name: t.title, slug: t.slug });
+  }
+  const { data: pendingRows } = titleIds.length > 0
+    ? await supabase
+        .from("fan_edits")
+        .select(
+          "id, title_id, platform, embed_url, thumbnail_url, creator_handle_displayed, creator_id, created_at",
+        )
+        .in("title_id", titleIds)
+        .eq("verification_status", "pending")
+        .eq("is_active", true)
+        .is("deleted_at", null)
+        .order("created_at", { ascending: false })
+    : { data: [] };
+  const pendingCreatorIds = Array.from(
+    new Set(
+      (pendingRows ?? [])
+        .map((r) => r.creator_id as string | null)
+        .filter((id): id is string => !!id),
+    ),
+  );
+  const pendingCreatorHandles = new Map<string, string>();
+  if (pendingCreatorIds.length > 0) {
+    const { data: creators } = await supabase
+      .from("public_creators")
+      .select("id, moonbeem_handle")
+      .in("id", pendingCreatorIds);
+    for (const c of (creators ?? []) as Array<{
+      id: string;
+      moonbeem_handle: string;
+    }>) {
+      pendingCreatorHandles.set(c.id, c.moonbeem_handle);
+    }
+  }
+  const pendingSubmissions: PartnerSubmission[] = (pendingRows ?? [])
+    .map((r) => {
+      const titleMeta = pendingByTitle.get(r.title_id as string);
+      if (!titleMeta) return null;
+      const moonbeemHandle = r.creator_id
+        ? (pendingCreatorHandles.get(r.creator_id as string) ?? null)
+        : null;
+      return {
+        id: r.id as string,
+        title_id: r.title_id as string,
+        title_name: titleMeta.name,
+        title_slug: titleMeta.slug,
+        platform: r.platform as
+          | "tiktok"
+          | "instagram"
+          | "youtube"
+          | "twitter",
+        embed_url: r.embed_url as string,
+        thumbnail_url: (r.thumbnail_url as string | null) ?? null,
+        creator_handle:
+          moonbeemHandle ??
+          (r.creator_handle_displayed as string | null) ??
+          "anon",
+        created_at: r.created_at as string,
+      };
+    })
+    .filter((x): x is PartnerSubmission => x !== null);
+  const submissionTitleOptions = titleRows
+    .filter((t) => t.is_active)
+    .map((t) => ({ id: t.id, slug: t.slug, title: t.title }));
+
   const titleSummary = titleRows.length === 1
     ? titleRows[0].title
     : `${titleRows.length} titles`;
@@ -1525,6 +1604,15 @@ export default async function PartnerDashboardPage({
             isAdmin={isPartnerAdmin}
             campaigns={campaigns}
             titles={wizardTitles}
+          />
+        </div>
+
+        <div className="mt-10">
+          <PartnerSubmissionsSection
+            partnerSlug={partner.slug as string}
+            isAdmin={isPartnerAdmin}
+            initialSubmissions={pendingSubmissions}
+            titles={submissionTitleOptions}
           />
         </div>
 

--- a/src/components/p/PartnerSubmissionsSection.tsx
+++ b/src/components/p/PartnerSubmissionsSection.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+// Pending-fan_edit-submissions queue on /p/[slug]/dashboard. Lists
+// every fan_edit with verification_status='pending' on a title
+// owned by this partner. Partner-admins can approve or reject each
+// one in place; viewers see the queue read-only with disabled
+// action buttons.
+//
+// Reject UI: clicking "Reject" expands an inline form with an
+// optional reason textarea (max 500 chars). Reason is
+// partner-internal audit only — the partner-decide API does not
+// send the creator a notification on rejection (super-admin reject
+// does, but partner-side moderation is intentionally silent in v1).
+//
+// Approve confirms via window.confirm() because approval is
+// irreversible-ish: it fulfills any open title_requests for the
+// title AND sends the creator an "approved" email. Reject's inline
+// form acts as its own confirmation (Confirm Reject / Cancel).
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+import {
+  fetchJson,
+  FetchJsonError,
+  RateLimitedError,
+} from "@/lib/fetch-json";
+
+export type PartnerSubmission = {
+  id: string;
+  title_id: string;
+  title_name: string;
+  title_slug: string;
+  platform: "tiktok" | "instagram" | "youtube" | "twitter";
+  embed_url: string;
+  thumbnail_url: string | null;
+  creator_handle: string;
+  created_at: string;
+};
+
+type Props = {
+  partnerSlug: string;
+  isAdmin: boolean;
+  initialSubmissions: PartnerSubmission[];
+  titles: { id: string; slug: string; title: string }[];
+};
+
+const REASON_MAX = 500;
+
+function humanizeErr(err: unknown): string {
+  if (err instanceof RateLimitedError || err instanceof FetchJsonError) {
+    return err.userMessage;
+  }
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+export default function PartnerSubmissionsSection({
+  partnerSlug,
+  isAdmin,
+  initialSubmissions,
+  titles,
+}: Props) {
+  const router = useRouter();
+  const [submissions, setSubmissions] =
+    useState<PartnerSubmission[]>(initialSubmissions);
+  const [titleFilter, setTitleFilter] = useState<string>("");
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [rejectingId, setRejectingId] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
+
+  const filtered = useMemo(() => {
+    if (!titleFilter) return submissions;
+    return submissions.filter((s) => s.title_id === titleFilter);
+  }, [submissions, titleFilter]);
+
+  async function handleApprove(s: PartnerSubmission) {
+    if (busyId || !isAdmin) return;
+    const ok = window.confirm(
+      `Approve "${s.title_name}" by @${s.creator_handle}?\n\nThis will close any open requests for this title and email the creator.`,
+    );
+    if (!ok) return;
+    setBusyId(s.id);
+    setErrorMsg(null);
+    const prev = submissions;
+    setSubmissions(prev.filter((x) => x.id !== s.id));
+    try {
+      await fetchJson(`/api/p/${partnerSlug}/fan-edits/${s.id}/decide`, {
+        method: "POST",
+        body: { decision: "approved" },
+      });
+      router.refresh();
+    } catch (err) {
+      setSubmissions(prev);
+      setErrorMsg(humanizeErr(err));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  function openRejectForm(s: PartnerSubmission) {
+    if (busyId || !isAdmin) return;
+    setRejectingId(s.id);
+    setRejectReason("");
+    setErrorMsg(null);
+  }
+
+  function cancelReject() {
+    setRejectingId(null);
+    setRejectReason("");
+  }
+
+  async function confirmReject(s: PartnerSubmission) {
+    if (busyId || !isAdmin) return;
+    const reason = rejectReason.trim();
+    if (reason.length > REASON_MAX) {
+      setErrorMsg(`Reason too long (max ${REASON_MAX} chars).`);
+      return;
+    }
+    setBusyId(s.id);
+    setErrorMsg(null);
+    const prev = submissions;
+    setSubmissions(prev.filter((x) => x.id !== s.id));
+    try {
+      await fetchJson(`/api/p/${partnerSlug}/fan-edits/${s.id}/decide`, {
+        method: "POST",
+        body: {
+          decision: "rejected",
+          ...(reason.length > 0 ? { reason } : {}),
+        },
+      });
+      router.refresh();
+    } catch (err) {
+      setSubmissions(prev);
+      setErrorMsg(humanizeErr(err));
+    } finally {
+      setBusyId(null);
+      setRejectingId(null);
+      setRejectReason("");
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-white/[0.02] p-5">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="rounded-full bg-moonbeem-pink/15 px-2.5 py-0.5 text-caption font-medium text-moonbeem-pink">
+          Submissions
+        </span>
+        <span className="text-caption text-moonbeem-ink-subtle">
+          {submissions.length}{" "}
+          {submissions.length === 1 ? "pending" : "pending"}
+        </span>
+      </div>
+      <p className="mt-1 text-body-sm text-moonbeem-ink-muted m-0">
+        {isAdmin
+          ? "Review and approve fan edits submitted to your titles. Approving closes any open requests for the title and notifies the creator; rejecting removes the edit from public surfaces without notifying the creator."
+          : "Pending fan edits submitted to your titles. Approving and rejecting is an admin-only action."}
+      </p>
+
+      {errorMsg && (
+        <p className="mt-3 text-body-sm text-moonbeem-magenta">{errorMsg}</p>
+      )}
+
+      {titles.length > 1 && (
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <label
+            htmlFor="submissions-title-filter"
+            className="text-caption text-moonbeem-ink-subtle"
+          >
+            Filter by title
+          </label>
+          <select
+            id="submissions-title-filter"
+            value={titleFilter}
+            onChange={(e) => setTitleFilter(e.target.value)}
+            className="rounded-md border border-white/10 bg-black/30 px-3 py-1.5 text-body-sm text-moonbeem-ink focus:border-moonbeem-pink focus:outline-none"
+          >
+            <option value="">All titles</option>
+            {titles.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.title}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div className="mt-4">
+        {filtered.length === 0 ? (
+          <p className="text-body-sm text-moonbeem-ink-muted m-0">
+            {submissions.length === 0
+              ? "No pending submissions."
+              : "No submissions match the current filter."}
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {filtered.map((s) => {
+              const isRejecting = rejectingId === s.id;
+              const isBusy = busyId === s.id;
+              return (
+                <li
+                  key={s.id}
+                  className="flex flex-col gap-3 rounded-md border border-white/10 bg-white/[0.02] p-3"
+                >
+                  <div className="flex items-center gap-3">
+                    {s.thumbnail_url ? (
+                      <div className="h-[60px] w-[40px] shrink-0 overflow-hidden rounded-sm bg-white/[0.03]">
+                        <Image
+                          src={s.thumbnail_url}
+                          alt={`${s.title_name} submission thumbnail`}
+                          width={40}
+                          height={60}
+                          className="h-full w-full object-cover"
+                          unoptimized
+                        />
+                      </div>
+                    ) : (
+                      <div
+                        className="h-[60px] w-[40px] shrink-0 rounded-sm border border-white/10 bg-white/[0.03]"
+                        aria-hidden="true"
+                      />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-body-sm text-moonbeem-ink">
+                        {s.title_name}
+                      </div>
+                      <div className="truncate font-mono text-caption text-moonbeem-ink-subtle">
+                        @{s.creator_handle} · {s.platform} · submitted{" "}
+                        {new Date(s.created_at).toLocaleDateString()}
+                      </div>
+                      <div className="mt-0.5 text-caption">
+                        <Link
+                          href={s.embed_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-moonbeem-ink-muted hover:text-moonbeem-pink"
+                        >
+                          View on {s.platform} ↗
+                        </Link>
+                        <span className="mx-2 text-moonbeem-ink-subtle">
+                          ·
+                        </span>
+                        <Link
+                          href={`/t/${s.title_slug}`}
+                          className="text-moonbeem-ink-muted hover:text-moonbeem-pink"
+                        >
+                          /t/{s.title_slug}
+                        </Link>
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 flex-col items-stretch gap-2 sm:flex-row">
+                      <button
+                        type="button"
+                        onClick={() => handleApprove(s)}
+                        disabled={!isAdmin || isBusy || isRejecting}
+                        title={
+                          !isAdmin
+                            ? "Admin-only action"
+                            : undefined
+                        }
+                        className="rounded-md border border-white/10 px-3 py-1.5 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-pink hover:text-moonbeem-pink disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        Approve
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => openRejectForm(s)}
+                        disabled={!isAdmin || isBusy || isRejecting}
+                        title={
+                          !isAdmin
+                            ? "Admin-only action"
+                            : undefined
+                        }
+                        className="rounded-md border border-white/10 px-3 py-1.5 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-magenta hover:text-moonbeem-magenta disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  </div>
+
+                  {isRejecting && (
+                    <div className="flex flex-col gap-2 rounded-md border border-moonbeem-magenta/30 bg-moonbeem-magenta/[0.04] p-3">
+                      <label
+                        htmlFor={`reject-reason-${s.id}`}
+                        className="text-caption text-moonbeem-ink-subtle"
+                      >
+                        Optional reason (partner-internal audit only;
+                        the creator is not notified)
+                      </label>
+                      <textarea
+                        id={`reject-reason-${s.id}`}
+                        value={rejectReason}
+                        onChange={(e) => setRejectReason(e.target.value)}
+                        maxLength={REASON_MAX}
+                        rows={2}
+                        placeholder="e.g. doesn't match our brand guidelines"
+                        className="rounded-md border border-white/10 bg-black/30 px-3 py-2 text-body-sm text-moonbeem-ink placeholder:text-moonbeem-ink-subtle focus:border-moonbeem-pink focus:outline-none"
+                      />
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="text-caption text-moonbeem-ink-subtle tabular-nums">
+                          {rejectReason.length} / {REASON_MAX}
+                        </span>
+                        <div className="flex gap-2">
+                          <button
+                            type="button"
+                            onClick={cancelReject}
+                            disabled={isBusy}
+                            className="rounded-md border border-white/10 px-3 py-1.5 text-body-sm text-moonbeem-ink-muted transition-colors hover:border-moonbeem-pink hover:text-moonbeem-pink disabled:opacity-40"
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => confirmReject(s)}
+                            disabled={isBusy}
+                            className="rounded-md border border-moonbeem-magenta/60 bg-moonbeem-magenta/10 px-3 py-1.5 text-body-sm text-moonbeem-magenta transition-colors hover:bg-moonbeem-magenta/20 disabled:opacity-40"
+                          >
+                            Confirm Reject
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/supabase/migrations/20260526000005_fan_edits_decision_audit.sql
+++ b/supabase/migrations/20260526000005_fan_edits_decision_audit.sql
@@ -1,0 +1,39 @@
+-- Audit columns for fan_edit decisions (approve / reject). Records
+-- WHO made the decision and WHEN, regardless of which path produced
+-- the decision (today: super-admin /api/admin/fan-edits/[id]/approve
+-- + /reject; new: partner-admin /api/p/[slug]/fan-edits/[id]/decide).
+-- Same column flips across all three routes — single audit trail.
+--
+-- Defaults & invariants:
+--   - decided_by_user_id UUID NULL — FK to auth.users with ON DELETE
+--     SET NULL. NULL means either "decision predates this audit
+--     layer" (every approved/rejected row currently in production)
+--     or "the deciding user has since been deleted from auth.users."
+--     The auth.users.id reference is consistent with how
+--     created_by_user_id is wired on other tables (campaigns,
+--     campaign_funding, partner_users).
+--   - decided_at TIMESTAMPTZ NULL — populated by the deciding route
+--     via new Date().toISOString() at write time. NULL means "row
+--     is still in a pre-decision state (auto_verified / needs_review
+--     / pending) OR was decided before this audit layer existed."
+--   - NO BACKFILL. Every approved or rejected fan_edit in production
+--     today predates this audit layer by definition; the columns
+--     stay NULL on those rows. The historical decided-by/at info
+--     was never captured anywhere else, so backfill isn't possible
+--     short of educated-guess inference from row created_at /
+--     created_by, which would create more confusion than truth.
+--   - No index in v1. Audit lookups are operator-rare; queries
+--     filter by primary keys or status enums first. If we ever need
+--     "who decided most recently" admin reports, a (decided_at DESC)
+--     index can be added then.
+--
+-- Related:
+--   - rejection_reason TEXT NULL (existing, added pre-this-layer) —
+--     populated on reject paths when a reason is supplied. The
+--     partner reject path takes an OPTIONAL reason; the super-admin
+--     reject path REQUIRES a reason (it's the input the creator
+--     notification email renders).
+
+alter table public.fan_edits
+  add column if not exists decided_by_user_id uuid references auth.users(id) on delete set null,
+  add column if not exists decided_at timestamptz;


### PR DESCRIPTION
## Summary

Partner-admins can now approve or reject pending fan_edits submitted to titles owned by their partner, from a new **Submissions** section on `/p/[slug]/dashboard`. Same approval authority as super-admins, scoped to `partner_users` membership.

## Changes

### New API: `POST /api/p/[slug]/fan-edits/[id]/decide`

Body: `{ decision: 'approved' | 'rejected', reason?: string }`

Auth (mirrors `/api/p/[slug]/campaigns/route.ts`):
- `getUser` → 401 if unauthenticated
- `enforce("partnerWrites", ...)` rate limit
- `SELECT partner by slug` → 404
- `super_admin` bypass via `getCurrentProfile.role`
- Otherwise: `partner_users.role='admin'` required → 403 for viewers / non-members
- Fan_edit's title MUST have `partner_id === this partner.id`. NULL (catalog titles) or cross-partner → `403 fan_edit_not_in_partner` (distinct error code from `not_authorized`)
- Already-decided → `409 not_pending` with `current_status` in response

Reason is partner-internal audit only — max 500 chars, server-validated, optional on reject and ignored on approve.

### Approve/reject asymmetry vs super-admin (intentional)

- **Approve**: same as super-admin path — fulfills any open `title_requests` for the title + sends `fan_edit_approved` email to the submitter via `after()`.
- **Reject**: **does NOT** send any creator email. Partner rejection is editorial, not platform moderation. (Super-admin reject still emails the creator and still requires a reason for the email body.)

### Migration `20260526000005_fan_edits_decision_audit.sql`

Adds `decided_by_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL` + `decided_at timestamptz` to `fan_edits`. **No backfill** — historical decisions predate this audit layer.

All three decision paths (partner decide, super-admin approve, super-admin reject) write the audit columns in the same UPDATE for a consistent trail going forward.

✅ Applied to prod; history corrected to `20260526000005`.

### New `<section>` on `/p/[slug]/dashboard`

"Submissions" — positioned between Campaigns and PartnerRates.

- Server-driven initial render of pending fan_edits scoped to the partner's titles (`title_id IN titleIds + verification_status='pending' + is_active=true + deleted_at IS NULL`)
- Optimistic UI on approve/reject with rollback on error
- Title filter dropdown when partner has >1 active title
- **Approve**: `window.confirm` (irreversible-ish — fulfills title_requests, emails creator)
- **Reject**: inline expand with optional 500-char `<textarea>` + "Confirm Reject" / "Cancel"
- **Viewer role**: queue read-only with disabled buttons tooltipped "Admin-only action"

### Cache revalidation

`revalidatePath` on every surface that filters fan_edits through the canonical readable gate:
- `/p/${slug}/dashboard`
- `/t/${titleSlug}`
- `/` (Trending / Recent / All Films carousels)

## Verification plan

After Vercel prod deploy, as `dlsickles@gmail` (super_admin + 1-2 Special admin):
1. `/p/1-2-special/dashboard` renders Submissions section
2. Existing pending fan_edits on 1-2 Special titles appear in the queue
3. Title filter dropdown works (if >1 active title)
4. Approve flow — status flips to `'approved'`, `decided_by_user_id` + `decided_at` populate, creator gets email, open title_requests close, fan_edit appears on `/t/[title-slug]` and homepage carousels
5. Reject flow (with optional reason) — status flips to `'rejected'`, audit columns populate, `rejection_reason` populated if provided, **no creator email**, fan_edit drops off public surfaces
6. One super-admin approve OR reject via existing `/admin/fan-edits` flow — confirm audit columns populate from that path too

🤖 Generated with [Claude Code](https://claude.com/claude-code)