### PR TITLE
map tooltips + city list scroll alignment

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -402,6 +402,7 @@ export default async function AdminDashboardPage(props: PageProps) {
                   `${r.country_code ?? ""}|${r.region_code ?? ""}|${r.city}`
                 }
                 emptyMessage="No location data available for this window."
+                maxHeightClass="max-h-[360px]"
               />
             </div>
           </div>

--- a/src/app/admin/titles/[slug]/TitleDetailTabs.tsx
+++ b/src/app/admin/titles/[slug]/TitleDetailTabs.tsx
@@ -1454,6 +1454,7 @@ function AnalyticsTab({
                 `${r.country_code ?? ""}|${r.region_code ?? ""}|${r.city}`
               }
               emptyMessage="No location data available for this window."
+              maxHeightClass="max-h-[360px]"
             />
           </div>
         </div>

--- a/src/app/p/[slug]/dashboard/page.tsx
+++ b/src/app/p/[slug]/dashboard/page.tsx
@@ -1563,7 +1563,7 @@ export default async function PartnerDashboardPage({
                   `${r.country_code ?? ""}|${r.region_code ?? ""}|${r.city}`
                 }
                 emptyMessage="No location data available for this window."
-                maxHeightClass="max-h-80"
+                maxHeightClass="max-h-[360px]"
               />
             </div>
           </div>

--- a/src/components/dashboard/TimeSeriesChart.tsx
+++ b/src/components/dashboard/TimeSeriesChart.tsx
@@ -7,7 +7,9 @@
 // ink-subtle. tabular-nums on tick labels for the editorial-precise
 // feel.
 //
-// Tooltip: nearest-data-point hover via @visx/tooltip's helpers.
+// No hover tooltip today — the chart is decorative trend at this
+// surface and detailed numbers live in the tables below. Adding a
+// nearest-point tooltip via @visx/tooltip is tracked separately.
 
 "use client";
 

--- a/src/components/dashboard/UsStateChoropleth.tsx
+++ b/src/components/dashboard/UsStateChoropleth.tsx
@@ -4,9 +4,10 @@
 // Internally we lookup USPS → FIPS for the us-atlas topology (which
 // keys states by 2-digit FIPS codes). Colors via a 5-step pink scale.
 //
-// The map is logo-only (no labels). Hover shows state code + count
-// via @visx/tooltip. Below the map, the page can render a top-states
-// table for explicit values.
+// The map is logo-only (no labels). Hover shows a styled tooltip
+// (state name + count + % of platform total) via @visx/tooltip's
+// useTooltipInPortal hook. Below the map, the page can render a
+// top-states table for explicit values.
 
 "use client";
 
@@ -17,6 +18,7 @@ import { scaleQuantile } from "@visx/scale";
 import { Group } from "@visx/group";
 import { feature } from "topojson-client";
 import type { FeatureCollection, Feature, Geometry } from "geojson";
+import { useTooltip, useTooltipInPortal } from "@visx/tooltip";
 // us-atlas ships pre-baked topojson at multiple resolutions. 10m is
 // detailed; 50m is lighter. Going with 10m for editorial polish on
 // large viewports. TypeScript resolves the JSON module via
@@ -63,6 +65,12 @@ type Props = {
 
 type StateFeature = Feature<Geometry, { name?: string }> & { id?: string };
 
+type TooltipData = {
+  name: string;
+  count: number;
+  pct: number;
+};
+
 function InnerMap({
   data,
   width,
@@ -88,6 +96,14 @@ function InnerMap({
     return m;
   }, [data]);
 
+  // Total across all input states — drives the "% of total" in the
+  // hover tooltip. Computed once per data change, not per render.
+  const total = useMemo(() => {
+    let s = 0;
+    for (const v of fipsCounts.values()) s += v;
+    return s;
+  }, [fipsCounts]);
+
   const colorScale = useMemo(() => {
     const values = Array.from(fipsCounts.values()).filter((v) => v > 0);
     if (values.length === 0) {
@@ -100,36 +116,89 @@ function InnerMap({
     return (v: number) => (v > 0 ? scale(v) : EMPTY_FILL);
   }, [fipsCounts]);
 
+  const {
+    tooltipOpen,
+    tooltipLeft,
+    tooltipTop,
+    tooltipData,
+    showTooltip,
+    hideTooltip,
+  } = useTooltip<TooltipData>();
+
+  // detectBounds keeps the tooltip on-screen near viewport edges; the
+  // portal escapes parent overflow:hidden so tooltips aren't clipped
+  // by the surrounding card. containerBounds gives us the live offset
+  // of the wrapper, so handleMove can pass container-local coords.
+  const { containerRef, containerBounds, TooltipInPortal } =
+    useTooltipInPortal({ detectBounds: true, scroll: true });
+
   if (width === 0) return null;
 
   return (
-    <svg width={width} height={height}>
-      <AlbersUsa<StateFeature>
-        data={states}
-        scale={Math.min(width, height * 1.6) * 1.05}
-        translate={[width / 2, height / 2]}
-      >
-        {({ features }) => (
-          <Group>
-            {features.map(({ feature: f, path }, i) => {
-              const fips = f.id?.toString().padStart(2, "0");
-              const count = fips ? fipsCounts.get(fips) ?? 0 : 0;
-              return (
-                <path
-                  key={`state-${i}`}
-                  d={path ?? ""}
-                  fill={colorScale(count)}
-                  stroke={STROKE}
-                  strokeWidth={0.5}
-                >
-                  <title>{`${f.properties?.name ?? "—"} · ${count.toLocaleString()}`}</title>
-                </path>
-              );
-            })}
-          </Group>
-        )}
-      </AlbersUsa>
-    </svg>
+    <div ref={containerRef} className="relative h-full w-full">
+      <svg width={width} height={height}>
+        <AlbersUsa<StateFeature>
+          data={states}
+          scale={Math.min(width, height * 1.6) * 1.05}
+          translate={[width / 2, height / 2]}
+        >
+          {({ features }) => (
+            <Group>
+              {features.map(({ feature: f, path }, i) => {
+                const fips = f.id?.toString().padStart(2, "0");
+                const count = fips ? fipsCounts.get(fips) ?? 0 : 0;
+                const name = f.properties?.name ?? "—";
+                const pct = total > 0 ? (count / total) * 100 : 0;
+                return (
+                  <path
+                    key={`state-${i}`}
+                    d={path ?? ""}
+                    fill={colorScale(count)}
+                    stroke={STROKE}
+                    strokeWidth={0.5}
+                    onMouseMove={(event) => {
+                      showTooltip({
+                        tooltipLeft: event.clientX - containerBounds.left,
+                        tooltipTop: event.clientY - containerBounds.top,
+                        tooltipData: { name, count, pct },
+                      });
+                    }}
+                    onMouseLeave={hideTooltip}
+                  />
+                );
+              })}
+            </Group>
+          )}
+        </AlbersUsa>
+      </svg>
+      {tooltipOpen && tooltipData && (
+        <TooltipInPortal
+          top={tooltipTop}
+          left={tooltipLeft}
+          unstyled
+          applyPositionStyle
+          // Offset above + to the right of the cursor so it doesn't
+          // sit under the pointer (which would block onMouseMove from
+          // firing on the next path).
+          offsetLeft={12}
+          offsetTop={-12}
+          className="pointer-events-none rounded-lg border border-white/10 bg-moonbeem-black/80 px-3 py-2 text-body-sm shadow-lg backdrop-blur-sm"
+        >
+          <div className="font-medium text-moonbeem-pink">
+            {tooltipData.name}
+          </div>
+          <div className="mt-0.5 text-moonbeem-ink tabular-nums">
+            {tooltipData.count.toLocaleString()}{" "}
+            {tooltipData.count === 1 ? "event" : "events"}
+            {total > 0 && tooltipData.count > 0 && (
+              <span className="ml-1.5 text-moonbeem-ink-subtle">
+                · {tooltipData.pct.toFixed(1)}%
+              </span>
+            )}
+          </div>
+        </TooltipInPortal>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Replace the choropleth's native SVG `<title>` element with a real styled tooltip via `@visx/tooltip` (`useTooltip` + `useTooltipInPortal`). State name in pink, count + units, percent of platform total (suppressed at count=0). One file edit, three surfaces benefit (`/p/[slug]/dashboard`, `/admin/dashboard`, `/admin/titles/[slug]`).
- Align city list scroll container with the `md:h-[360px]` map height across all three geo surfaces: partner `max-h-80` → `max-h-[360px]`; admin global + admin per-title gain `maxHeightClass="max-h-[360px]"` (previously row-capped at 10 with no scroll container). Row caps unchanged.
- Correct two stale comments: `UsStateChoropleth.tsx` header (claimed visx/tooltip was wired) and `TimeSeriesChart.tsx:10` (claimed nearest-point tooltip — TimeSeriesChart still has no hover tooltip; tracked separately).

## Test plan
- [ ] `/p/1-2-special/dashboard` — hover CA/NY/TX: tooltip shows state name in pink + count + percent
- [ ] Hover Wyoming (zero-data state): tooltip shows just "Wyoming · 0 events" (no percent line)
- [ ] Tooltip stays on-screen near viewport edges (detectBounds)
- [ ] Crossing state boundaries — tooltip updates smoothly, no flicker, no stuck state
- [ ] `/p/1-2-special/dashboard` city list — scroll container aligns visually with map
- [ ] `/admin/dashboard` — city list scrolls
- [ ] `/admin/titles/erupcja` — city list scrolls
- [ ] Mobile — hover-tooltip absence is neutral (expected, not a regression vs the native `<title>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)