### PR TITLE
carousel scroll UX: override smooth, snap-proximity, touch-action, wheel translation

### DIFF
--- a/src/components/FanEditCarousel.tsx
+++ b/src/components/FanEditCarousel.tsx
@@ -51,7 +51,7 @@ export default function FanEditCarousel({ title, fanEdits }: Props) {
       <div className="relative">
         <motion.div
           ref={scrollRef}
-          className="flex select-none snap-x snap-mandatory gap-4 overflow-x-auto px-6 pb-2 [scrollbar-width:none] [-webkit-user-drag:none] [&::-webkit-scrollbar]:hidden"
+          className="flex select-none snap-x snap-proximity gap-4 overflow-x-auto px-6 pb-2 [scrollbar-width:none] [scroll-behavior:auto] [touch-action:pan-x] [scroll-padding-left:1.5rem] [-webkit-user-drag:none] [&::-webkit-scrollbar]:hidden"
           role="list"
           onDragStart={(e) => e.preventDefault()}
           variants={stagger}

--- a/src/components/PartnerLogoStrip.tsx
+++ b/src/components/PartnerLogoStrip.tsx
@@ -67,7 +67,7 @@ export default function PartnerLogoStrip({ partners }: Props) {
         // site-wide consistency. Cursor grab feedback indicates the
         // drag affordance; useDragScroll swaps to grabbing on
         // mousedown.
-        className="flex select-none items-center gap-4 overflow-x-auto px-6 py-4 [scrollbar-width:none] [-webkit-user-drag:none] [&::-webkit-scrollbar]:hidden cursor-grab"
+        className="flex select-none items-center gap-4 overflow-x-auto px-6 py-4 [scrollbar-width:none] [scroll-behavior:auto] [touch-action:pan-x] [scroll-padding-left:1.5rem] [-webkit-user-drag:none] [&::-webkit-scrollbar]:hidden cursor-grab"
         role="list"
         onDragStart={(e) => e.preventDefault()}
         variants={stagger}

--- a/src/components/TitleCarousel.tsx
+++ b/src/components/TitleCarousel.tsx
@@ -57,7 +57,7 @@ export default function TitleCarousel({ title, titles }: Props) {
       <div className="relative">
         <motion.div
           ref={scrollRef}
-          className="flex select-none snap-x snap-mandatory gap-4 overflow-x-auto px-6 pb-2 [scrollbar-width:none] [-webkit-user-drag:none] [&::-webkit-scrollbar]:hidden"
+          className="flex select-none snap-x snap-proximity gap-4 overflow-x-auto px-6 pb-2 [scrollbar-width:none] [scroll-behavior:auto] [touch-action:pan-x] [scroll-padding-left:1.5rem] [-webkit-user-drag:none] [&::-webkit-scrollbar]:hidden"
           role="list"
           onDragStart={(e) => e.preventDefault()}
           variants={stagger}

--- a/src/hooks/useDragScroll.ts
+++ b/src/hooks/useDragScroll.ts
@@ -1,6 +1,11 @@
 import { useEffect, useRef } from "react";
 
 const DRAG_THRESHOLD = 5;
+// 1:1 mapping from wheel deltaY → horizontal scrollLeft. Trackpad
+// users with smooth-scroll deltas naturally produce small values
+// (feels weighted); standard wheel mice produce ~100/click which
+// advances roughly half a card per click. Both feel right.
+const WHEEL_SCALE = 1.0;
 
 export function useDragScroll() {
   const ref = useRef<HTMLDivElement>(null);
@@ -60,11 +65,38 @@ export function useDragScroll() {
       }
     };
 
+    // Translate vertical wheel into horizontal scroll for wheel-mouse
+    // users (trackpad horizontal pan is already handled natively by
+    // overflow-x-auto, so we explicitly defer to it via the
+    // |deltaY| > |deltaX| check).
+    //
+    // shift+wheel is a power-user idiom for horizontal scrolling and
+    // many users have muscle memory for it — we pass that through
+    // untouched so the native shift+wheel behavior is preserved.
+    //
+    // Scroll-chaining: when the carousel is at an edge in the wheel
+    // direction, release the event so the page can vertical-scroll
+    // past the section. Without this, users get stuck on a carousel
+    // section that's tall enough to fill the viewport.
+    const onWheel = (e: WheelEvent) => {
+      if (e.shiftKey) return;
+      if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return;
+      const atStart = el.scrollLeft <= 0;
+      const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 1;
+      if (e.deltaY > 0 && atEnd) return;
+      if (e.deltaY < 0 && atStart) return;
+      e.preventDefault();
+      el.scrollLeft += e.deltaY * WHEEL_SCALE;
+    };
+
     el.addEventListener("mousedown", onMouseDown);
     el.addEventListener("mouseleave", endDrag);
     el.addEventListener("mouseup", endDrag);
     el.addEventListener("mousemove", onMouseMove);
     el.addEventListener("click", onClickCapture, true);
+    // passive: false required so preventDefault() actually suppresses
+    // the page's vertical scroll.
+    el.addEventListener("wheel", onWheel, { passive: false });
 
     el.style.cursor = "grab";
 
@@ -74,6 +106,7 @@ export function useDragScroll() {
       el.removeEventListener("mouseup", endDrag);
       el.removeEventListener("mousemove", onMouseMove);
       el.removeEventListener("click", onClickCapture, true);
+      el.removeEventListener("wheel", onWheel);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
Tier 1 of the carousel scroll UX fix. Five small changes across `useDragScroll.ts` and the three carousel components' class strings — no library introduced.

- `onWheel` handler in `useDragScroll`: vertical wheel → horizontal `scrollLeft` for wheel-mouse users; trackpad horizontal pan untouched; shift+wheel passthrough; scroll-chains at edges.
- `[scroll-behavior:auto]` on each carousel container — local override of the global smooth rule so drag + wheel writes apply instantly.
- `snap-mandatory` → `snap-proximity` — mobile flick momentum carries; snap engages on release, not mid-flick.
- `[touch-action:pan-x]` — explicit horizontal-only gesture handling.
- `[scroll-padding-left:1.5rem]` — matches `px-6` so every snap target lands at the same 24px gutter.

## Test plan

Desktop:
- [ ] Wheel mouse on a homepage carousel — scrolls horizontally
- [ ] Shift+wheel on a carousel — page still scrolls vertically (native preserved)
- [ ] At carousel start, wheel up — page scrolls past (chain releases)
- [ ] At carousel end, wheel down — page scrolls past
- [ ] Click-and-drag — tracks cursor smoothly, no rubber-band lag
- [ ] Short drag release — gentle settle to nearest card, not yanked back
- [ ] Trackpad two-finger horizontal — still native and smooth

Mobile:
- [ ] Swipe a fan_edits carousel — momentum carries naturally
- [ ] Snap engages on release, not mid-flick
- [ ] Vertical page scroll still works while finger is on a carousel
- [ ] Pinch-zoom doesn't trigger a swipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)