### PR TITLE
youtube import: preserve video ID in url normalization, fix misleading error copy

### DIFF
--- a/src/app/admin/fan-edits/new/SingleUploadClient.tsx
+++ b/src/app/admin/fan-edits/new/SingleUploadClient.tsx
@@ -393,7 +393,7 @@ export default function SingleUploadClient() {
                 )}
                 {metadata.metrics.error && (
                   <p className="text-body-sm text-moonbeem-magenta">
-                    EnsembleData warning: {metadata.metrics.error}
+                    Import warning: {metadata.metrics.error}
                   </p>
                 )}
               </div>

--- a/src/lib/fan-edits/url-parser.ts
+++ b/src/lib/fan-edits/url-parser.ts
@@ -218,10 +218,24 @@ export function parseFanEditUrl(rawUrl: string): ParsedFanEditUrl | null {
   // URLs). Force /reel/{shortcode} on www.instagram.com — IG
   // redirects between forms in the browser regardless, so all four
   // remain reachable from a single canonical stored URL.
+  //
+  // YouTube exception: the video ID lives in the QUERY STRING for
+  // /watch?v=ID URLs, so the generic "host + path" path-only
+  // normalization would silently drop it and downstream
+  // parseShortcodeFromUrl(normalizedUrl) → null → parse_error.
+  // The /shorts/, /embed/, /v/, /live/ path forms AND youtu.be all
+  // resolve to the same 11-char content ID; canonicalize every
+  // YouTube URL to https://www.youtube.com/watch?v={contentId}.
+  // Dedup safety: fan_edits' unique constraint is on
+  // (title_id, post_id), not embed_url, so existing rows stored in
+  // any URL form (e.g. /shorts/<id>) still dedupe against a
+  // re-import via canonical form (same post_id).
   const normalizedUrl =
     platform === "instagram"
       ? `https://www.instagram.com/reel/${contentId}`
-      : `https://${parsed.host}${parsed.pathname.replace(/\/$/, "")}`;
+      : platform === "youtube"
+        ? `https://www.youtube.com/watch?v=${contentId}`
+        : `https://${parsed.host}${parsed.pathname.replace(/\/$/, "")}`;
 
   return { platform, contentId, handle, normalizedUrl };
 }


### PR DESCRIPTION
## Summary
- `parseFanEditUrl` now canonicalizes every YouTube URL form (/watch?v=, /shorts/, /embed/, /v/, /live/, youtu.be) to `https://www.youtube.com/watch?v={contentId}`. The previous generic "host + path" normalization silently dropped the `?v=` query string, leaving downstream `parseShortcodeFromUrl` with no video ID and surfacing `parse_error` — without ever calling YT Data API. The single-URL admin flow effectively never worked for YouTube; the 15 existing rows came in via the CSV bulk importer which bypasses `parseFanEditUrl`.
- `SingleUploadClient.tsx` warning copy: `"EnsembleData warning"` → `"Import warning"`. YouTube doesn't touch EnsembleData; the previous label misattributed every YouTube failure.

Dedup safety: fan_edits' unique constraint is on `(title_id, post_id)`, not `embed_url`. The one existing row stored as `/shorts/<id>` dedupes correctly against future re-imports via the canonical form (same `post_id`).

## Test plan
On `/admin/fan-edits/new`:
- [ ] Paste `https://www.youtube.com/watch?v=yDQmkyn6Xdk` (the failing Searchlight Ann Lee featurette). Metadata populates: views, thumbnail, channel name. No `parse_error`, no "EnsembleData" copy.
- [ ] Paste a `youtu.be/...` short link. Canonicalizes and resolves.
- [ ] Paste a known-working URL (`youtube.com/watch?v=eiX0Ze0PKjk`). Single-URL flow now handles it (only worked via CSV before).
- [ ] If metadata resolves cleanly: attach the Ann Lee featurette to `the-testament-of-ann-lee-2025`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)