### PR TITLE
youtube import: auto-derive creator from channelTitle + always-visible manual handle override

### DIFF
--- a/src/app/admin/fan-edits/new/SingleUploadClient.tsx
+++ b/src/app/admin/fan-edits/new/SingleUploadClient.tsx
@@ -90,6 +90,12 @@ export default function SingleUploadClient() {
   const [creatorResults, setCreatorResults] = useState<CreatorResult[]>([]);
   const [creatorSearching, setCreatorSearching] = useState(false);
 
+  // Editable creator handle. Pre-fills from metadata.sourceHandle
+  // when /fetch-metadata returns; admin can override before save.
+  // Always-visible (every platform), so it doubles as a way to
+  // correct a wrong URL-detected handle on TikTok/IG/X too.
+  const [handleInput, setHandleInput] = useState("");
+
   const [notes, setNotes] = useState("");
 
   const [titleQuery, setTitleQuery] = useState("");
@@ -103,6 +109,15 @@ export default function SingleUploadClient() {
 
   const titleSearchAbort = useRef<AbortController | null>(null);
   const creatorSearchAbort = useRef<AbortController | null>(null);
+
+  // Reset handle input whenever a fresh metadata response arrives.
+  // sourceHandle is the route's resolution chain
+  // (parsed.handle → metrics.creator_handle_displayed → channelTitle
+  // for YouTube), so this pre-fills with the best auto-detected
+  // value. Admin sees it, accepts or edits.
+  useEffect(() => {
+    setHandleInput(metadata?.sourceHandle ?? "");
+  }, [metadata?.sourceHandle]);
 
   // Detect platform as user types (cheap, no API call).
   useEffect(() => {
@@ -249,7 +264,7 @@ export default function SingleUploadClient() {
         body: JSON.stringify({
           url: metadata.parsed.normalizedUrl,
           title_id: selectedTitle.id,
-          handle: metadata.sourceHandle ?? undefined,
+          handle: handleInput.trim() || undefined,
           attributed_creator_id: effectiveCreator?.id ?? null,
           notes: notes.trim() || undefined,
           metrics: metadata.metrics,
@@ -269,6 +284,7 @@ export default function SingleUploadClient() {
       setCreatorPickerOpen(false);
       setCreatorQuery("");
       setCreatorResults([]);
+      setHandleInput("");
       setNotes("");
       setTitleQuery("");
       setSelectedTitle(null);
@@ -403,19 +419,41 @@ export default function SingleUploadClient() {
 
         {metadata && (
           <div className="flex flex-col gap-5">
-            {/* Social attribution (read-only) */}
-            <div className="flex flex-col gap-1 rounded-md border border-white/10 bg-white/[0.02] p-3">
+            {/* Social attribution — editable. Pre-filled from the
+                route's sourceHandle resolution chain; admin can
+                accept or override (works for any platform, including
+                fixing a wrong URL-detected handle). On save, blank
+                falls back to parsed.handle server-side (typically
+                null for YouTube without a /@channel/ segment); any
+                non-blank value passes through verbatim, then
+                insert.ts strips the leading @ and lowercases. */}
+            <div className="flex flex-col gap-2 rounded-md border border-white/10 bg-white/[0.02] p-3">
               <span className="text-body-sm text-moonbeem-ink-subtle uppercase tracking-wider">
                 Posted by
               </span>
-              <p className="text-body text-moonbeem-ink">
-                {metadata.sourceHandle
-                  ? `@${metadata.sourceHandle}`
-                  : "(handle not detected)"}{" "}
-                <span className="text-moonbeem-ink-subtle">
+              <div className="flex items-center gap-2">
+                <span className="text-body text-moonbeem-ink-subtle">@</span>
+                <input
+                  type="text"
+                  value={handleInput}
+                  onChange={(e) => setHandleInput(e.target.value)}
+                  placeholder={
+                    metadata.sourceHandle
+                      ? ""
+                      : "handle not detected — enter to attribute"
+                  }
+                  className="flex-1 bg-transparent border border-white/15 rounded-md px-3 py-1.5 text-body text-moonbeem-ink placeholder:text-moonbeem-ink-subtle focus:outline-none focus:border-moonbeem-pink"
+                />
+                <span className="text-body-sm text-moonbeem-ink-subtle whitespace-nowrap">
                   on {platformLabel(metadata.parsed.platform)}
                 </span>
-              </p>
+              </div>
+              {metadata.sourceHandle && (
+                <p className="text-caption text-moonbeem-ink-subtle">
+                  Auto-detected: @{metadata.sourceHandle}. Edit to
+                  override.
+                </p>
+              )}
             </div>
 
             {/* Network attribution */}

--- a/src/app/api/admin/fan-edits/fetch-metadata/route.ts
+++ b/src/app/api/admin/fan-edits/fetch-metadata/route.ts
@@ -72,10 +72,35 @@ export async function POST(request: NextRequest) {
     embed_url: parsed.normalizedUrl,
   });
 
-  // Resolve the handle (parsed > metrics-returned) against
-  // creator_socials so the UI can show auto-attribution status.
+  // YouTube fallback: `channelTitle` from snippet is already in
+  // raw_payload (fetchVideoStats extracts it via mapVideoItem) but
+  // fetchYouTubeMetrics keeps creator_handle_displayed null by
+  // design — to preserve refresh idempotency, the metric layer
+  // never writes channelTitle into the DB field. The preview route
+  // is the right place to surface it as a display fallback so
+  // admins see "Searchlight Pictures" instead of "(handle not
+  // detected)" on /watch?v= URLs. raw_payload is typed unknown;
+  // guard every access defensively and fall through to null on
+  // any shape mismatch.
+  let youtubeChannelTitle: string | null = null;
+  if (parsed.platform === "youtube" && metrics.raw_payload && typeof metrics.raw_payload === "object") {
+    const items = (metrics.raw_payload as { items?: unknown }).items;
+    if (Array.isArray(items) && items.length > 0) {
+      const snippet = (items[0] as { snippet?: unknown }).snippet;
+      if (snippet && typeof snippet === "object") {
+        const title = (snippet as { channelTitle?: unknown }).channelTitle;
+        if (typeof title === "string" && title.trim()) {
+          youtubeChannelTitle = title.trim();
+        }
+      }
+    }
+  }
+
+  // Resolve the handle (parsed > metrics-returned > YouTube
+  // channelTitle fallback) against creator_socials so the UI can
+  // show auto-attribution status.
   const resolvedHandle =
-    parsed.handle ?? metrics.creator_handle_displayed ?? null;
+    parsed.handle ?? metrics.creator_handle_displayed ?? youtubeChannelTitle ?? null;
   let resolvedCreator: ResolvedCreator | null = null;
   if (resolvedHandle) {
     const sb = createServiceRoleClient();


### PR DESCRIPTION
## Summary
- `/api/admin/fan-edits/fetch-metadata` reads `channelTitle` from `metrics.raw_payload.items[0].snippet.channelTitle` when platform is `youtube` and uses it as the third fallback in `resolvedHandle`. Defensively guarded — any shape mismatch falls through to null, never throws. The metric layer (`fetchYouTubeMetrics`) is untouched so refresh stays idempotent (creator_handle_displayed stays null in the typed result on refresh).
- `SingleUploadClient` turns the read-only "Posted by" line into an always-visible editable text input pre-filled from `metadata.sourceHandle`. On save, the field's value goes through `body.handle` (which `single/route.ts` already accepted as an override; the frontend just never exposed it). Works for every platform — TikTok/IG/X now also get an "edit auto-detected handle" affordance.

Backend stub-creation path unchanged. `insert.ts` already strips a leading `@` and lowercases the handle before passing to `find_or_create_stub_creator`.

## Test plan
On `/admin/fan-edits/new`:
- [ ] Paste `https://www.youtube.com/watch?v=yDQmkyn6Xdk`. "Posted by" pre-fills with "Searchlight Pictures" (or whatever YT API returns); "Auto-detected: @Searchlight Pictures. Edit to override." subtext renders.
- [ ] Edit the field, save with the chosen handle attributed to `the-testament-of-ann-lee-2025`.
- [ ] Regression: paste a TikTok or IG URL. Handle pre-fills with the URL-detected/EnsembleData-resolved value. Field is editable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)