### PR TITLE
creator-facing active-campaign discovery: carousel + title-page pill

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import {
   getAllFilms,
   getFeaturedTitles,
   getRecentFanEdits,
+  getTitlesWithActiveCampaigns,
   getTrendingFanEdits,
 } from "@/lib/queries/titles";
 import { getMarqueePartners } from "@/lib/queries/partners";
@@ -17,15 +18,23 @@ export default async function Home() {
   // Fetch every section's data + the configured section order in
   // parallel. Each carousel is a separate query (already the case
   // pre-slice-D); we just add one more for the order config.
-  const [order, featured, recentFanEdits, partners, allFilms, trending] =
-    await Promise.all([
-      getHomepageSectionOrder(),
-      getFeaturedTitles(),
-      getRecentFanEdits(12),
-      getMarqueePartners(),
-      getAllFilms(),
-      getTrendingFanEdits(12),
-    ]);
+  const [
+    order,
+    featured,
+    recentFanEdits,
+    partners,
+    allFilms,
+    trending,
+    activeCampaignTitles,
+  ] = await Promise.all([
+    getHomepageSectionOrder(),
+    getFeaturedTitles(),
+    getRecentFanEdits(12),
+    getMarqueePartners(),
+    getAllFilms(),
+    getTrendingFanEdits(12),
+    getTitlesWithActiveCampaigns(),
+  ]);
 
   // Renderer-per-slug — keeps the conditional length>0 guard
   // co-located with each section. Returning null means "the section
@@ -48,6 +57,19 @@ export default async function Home() {
     "all-films": () =>
       allFilms.length > 0 ? (
         <TitleCarousel title="All Films" titles={allFilms} />
+      ) : null,
+    "active-campaigns": () =>
+      activeCampaignTitles.length > 0 ? (
+        <TitleCarousel
+          title="Films you can earn from right now"
+          titles={activeCampaignTitles.map((t) => ({
+            id: t.id,
+            slug: t.slug,
+            title: t.title,
+            poster_url: t.poster_url,
+            cpmDisplay: t.cpm_display,
+          }))}
+        />
       ) : null,
   };
 

--- a/src/app/t/[slug]/page.tsx
+++ b/src/app/t/[slug]/page.tsx
@@ -8,6 +8,7 @@ import {
   getActiveOffersForTitle,
   getActiveStillsForTitle,
   getTitleBySlug,
+  isTitleInActiveCampaign,
   type TitleOffer,
 } from "@/lib/queries/titles";
 import TitleTabs from "@/components/TitleTabs";
@@ -113,12 +114,14 @@ export default async function TitlePage({ params }: PageProps) {
     partner_id: title.partner_id,
   });
   if (!visible) notFound();
-  const [offers, fanEdits, clips, stills] = await Promise.all([
-    getActiveOffersForTitle(title.id),
-    getActiveFanEditsForTitle(title.id),
-    getActiveClipsForTitle(title.id),
-    getActiveStillsForTitle(title.id),
-  ]);
+  const [offers, fanEdits, clips, stills, hasActiveCampaign] =
+    await Promise.all([
+      getActiveOffersForTitle(title.id),
+      getActiveFanEditsForTitle(title.id),
+      getActiveClipsForTitle(title.id),
+      getActiveStillsForTitle(title.id),
+      isTitleInActiveCampaign(title.id),
+    ]);
 
   const supabase = await createClient();
   const {
@@ -239,6 +242,20 @@ export default async function TitlePage({ params }: PageProps) {
             aboutContent={aboutContent}
             fanEditsContent={
               <>
+                {/* Active-campaign indicator. Rendered whenever the
+                    title sits in at least one funded-or-live
+                    campaign, regardless of viewer auth state — anon
+                    visitors see the same cue as signed-in creators
+                    and can act on it after signing up. The boolean
+                    comes from a service-role check
+                    (isTitleInActiveCampaign) because campaigns are
+                    deny-all under RLS; no campaign internals
+                    (pool, fee, partner, ids) cross the boundary. */}
+                {hasActiveCampaign ? (
+                  <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-moonbeem-pink/15 px-3 py-1 text-body-sm font-medium text-moonbeem-pink">
+                    Active Campaign · Earn from your Edit
+                  </div>
+                ) : null}
                 {/* Block 3 entry point: signed-in viewers see a link
                     to /c/<their-handle>/upload?title_id=<this title>.
                     The upload page itself redirects to /me/edit?

--- a/src/components/TitleCard.tsx
+++ b/src/components/TitleCard.tsx
@@ -7,9 +7,16 @@ import type { Title } from "@/lib/queries/titles";
 
 type Props = {
   title: Pick<Title, "id" | "slug" | "title" | "poster_url">;
+  // Optional CPM chip rendered in the top-right corner of the
+  // poster. Only the active-campaigns homepage carousel passes this
+  // today; all other call sites omit it and the chip is not
+  // rendered. The string is preformatted server-side
+  // ("$X.XX per 1,000 views") so the card doesn't reach for any
+  // campaign internals.
+  cpmDisplay?: string | null;
 };
 
-export default function TitleCard({ title }: Props) {
+export default function TitleCard({ title, cpmDisplay }: Props) {
   const href = `/t/${title.slug}`;
 
   return (
@@ -42,6 +49,11 @@ export default function TitleCard({ title }: Props) {
           </span>
         </div>
       )}
+      {cpmDisplay ? (
+        <span className="pointer-events-none absolute right-2 top-2 rounded-full bg-moonbeem-pink px-2 py-0.5 text-[10px] font-semibold text-moonbeem-navy shadow-md">
+          {cpmDisplay}
+        </span>
+      ) : null}
     </Link>
   );
 }

--- a/src/components/TitleCarousel.tsx
+++ b/src/components/TitleCarousel.tsx
@@ -7,12 +7,16 @@ import TitleCard from "./TitleCard";
 import { useDragScroll } from "@/hooks/useDragScroll";
 import { fadeIn, noMotion, stagger } from "@/lib/motion";
 
+type CarouselTitle = Pick<Title, "id" | "slug" | "title" | "poster_url"> & {
+  cpmDisplay?: string | null;
+};
+
 type Props = {
   // Section header above the carousel. Omit / empty string to render
   // the carousel without a header (e.g. partner-catalog page where
   // the hero already names the section).
   title?: string;
-  titles: Pick<Title, "id" | "slug" | "title" | "poster_url">[];
+  titles: CarouselTitle[];
 };
 
 export default function TitleCarousel({ title, titles }: Props) {
@@ -71,7 +75,7 @@ export default function TitleCarousel({ title, titles }: Props) {
               className="w-[160px] shrink-0 snap-start md:w-[220px] lg:w-[240px]"
               variants={cardVariant}
             >
-              <TitleCard title={t} />
+              <TitleCard title={t} cpmDisplay={t.cpmDisplay ?? null} />
             </motion.div>
           ))}
         </motion.div>

--- a/src/lib/homepage-sections.ts
+++ b/src/lib/homepage-sections.ts
@@ -21,6 +21,7 @@ export const HOMEPAGE_SECTION_SLUGS = [
   "trending",
   "recent",
   "all-films",
+  "active-campaigns",
 ] as const;
 
 export type HomepageSectionSlug = (typeof HOMEPAGE_SECTION_SLUGS)[number];
@@ -31,17 +32,26 @@ export const HOMEPAGE_SECTION_LABELS: Record<HomepageSectionSlug, string> = {
   trending: "Trending Edits",
   recent: "Recent Edits",
   "all-films": "All Films",
+  "active-campaigns": "Films you can earn from right now",
 };
 
 // Default order matches today's hardcoded JSX in src/app/page.tsx.
 // Used as the fallback when the DB returns empty / partial state and
 // as the seed value in the migration.
+//
+// "active-campaigns" intentionally has no row in homepage_sections
+// (the CHECK constraint still lists the original five). The loader's
+// missing-slug-append branch (the loop below the seen-set) will
+// append it to the rendered order, so the section lands at the
+// bottom of the homepage until a follow-up migration drops + recreates
+// the CHECK constraint and inserts a row positioning it explicitly.
 export const DEFAULT_HOMEPAGE_SECTION_ORDER: HomepageSectionSlug[] = [
   "marquee",
   "featured",
   "trending",
   "recent",
   "all-films",
+  "active-campaigns",
 ];
 
 const KNOWN_SLUGS = new Set<string>(HOMEPAGE_SECTION_SLUGS);

--- a/src/lib/queries/titles.ts
+++ b/src/lib/queries/titles.ts
@@ -521,6 +521,117 @@ export async function getRecentFanEdits(
   });
 }
 
+// Creator-facing "films you can earn from" loader.
+//
+// campaigns / campaign_titles have RLS enabled with zero policies —
+// total deny for anon and authenticated. Reads run via service-role
+// (same pattern as the partner dashboard) and the boundary is the
+// returned shape: only title fields a creator should see, plus a
+// preformatted cpm_display string. Pool size, pool remaining, fee
+// pct, settling days, funded_at, partner identity, and campaign ids
+// stay server-side.
+//
+// Dedupe by title_id (one title can sit in multiple active campaigns
+// — Erupcja is in three today). FIFO-by-funded_at allocation between
+// concurrent campaigns is an internal detail; the surface says "this
+// film is earnable" and shows the highest CPM across that title's
+// active campaigns.
+//
+// "Active" = status IN ('funded','live'). The metering job
+// (supabase/functions/campaign-metering/index.ts:179) bills both —
+// `funded → live` is a side effect of the first payout, not a
+// payout gate. A creator submitting an edit on a funded-but-not-yet-
+// live title will earn on the next settle.
+//
+// Filters titles to is_public=true AND is_active=true. An unlisted or
+// retired title backing an active campaign would be a data-quality
+// problem (the partner-create flow blocks this); the filter is
+// defensive so we never surface a title a viewer can't load.
+export type EarnableTitle = Pick<
+  Title,
+  "id" | "slug" | "title" | "poster_url"
+> & {
+  cpm_display: string;
+};
+
+export async function getTitlesWithActiveCampaigns(): Promise<EarnableTitle[]> {
+  const supabase = createServiceRoleClient();
+  const { data, error } = await supabase
+    .from("campaign_titles")
+    .select(
+      "title_id, campaigns!inner(status, cpm_rate_cents), titles!inner(id, slug, title, poster_url, is_public, is_active)",
+    )
+    .in("campaigns.status", ["funded", "live"])
+    .eq("titles.is_public", true)
+    .eq("titles.is_active", true);
+  if (error || !data) return [];
+
+  type Row = {
+    title_id: string;
+    campaigns: { status: string; cpm_rate_cents: number } | null;
+    titles: {
+      id: string;
+      slug: string;
+      title: string;
+      poster_url: string | null;
+      is_public: boolean;
+      is_active: boolean;
+    } | null;
+  };
+
+  const byTitle = new Map<string, EarnableTitle>();
+  for (const r of data as unknown as Row[]) {
+    if (!r.titles || !r.campaigns) continue;
+    const cents = r.campaigns.cpm_rate_cents;
+    const existing = byTitle.get(r.title_id);
+    if (existing) {
+      const prevCents = parseDisplayCents(existing.cpm_display);
+      if (cents > prevCents) {
+        existing.cpm_display = formatCpmDisplay(cents);
+      }
+      continue;
+    }
+    byTitle.set(r.title_id, {
+      id: r.titles.id,
+      slug: r.titles.slug,
+      title: r.titles.title,
+      poster_url: r.titles.poster_url,
+      cpm_display: formatCpmDisplay(cents),
+    });
+  }
+  return Array.from(byTitle.values());
+}
+
+function formatCpmDisplay(cents: number): string {
+  return `$${(cents / 100).toFixed(2)} per 1,000 views`;
+}
+
+function parseDisplayCents(display: string): number {
+  // Inverse of formatCpmDisplay — used only for max-CPM comparison
+  // inside the dedupe loop. Format is "$X.XX per 1,000 views".
+  const m = display.match(/^\$(\d+(?:\.\d+)?)/);
+  return m ? Math.round(Number(m[1]) * 100) : 0;
+}
+
+// Single-title check for /t/[slug]. Same RLS posture as the carousel
+// loader: campaigns/campaign_titles are deny-all under RLS so this
+// runs via service-role. Returns a boolean only — no CPM, no
+// campaign metadata — to keep the title-page surface minimal and to
+// avoid widening any shared Title shape.
+export async function isTitleInActiveCampaign(
+  titleId: string,
+): Promise<boolean> {
+  const supabase = createServiceRoleClient();
+  const { data, error } = await supabase
+    .from("campaign_titles")
+    .select("campaign_id, campaigns!inner(status)")
+    .eq("title_id", titleId)
+    .in("campaigns.status", ["funded", "live"])
+    .limit(1);
+  if (error || !data) return false;
+  return data.length > 0;
+}
+
 // Block 3 user-submission queries. Pending / rejected fan_edits never
 // surface on public profiles or title pages (their RLS keeps anon out
 // already); these helpers run via service-role for the submitter's


### PR DESCRIPTION
## Summary
- New homepage carousel **"Films you can earn from right now"** surfaces titles with funded/live campaigns. Cards show a pink `$X.XX per 1,000 views` chip in the top-right.
- `/t/[slug]` gets an **"Active Campaign · Earn from your Edit"** pill above the existing "Made a fan edit for this? Add yours →" CTA when the title has at least one funded/live campaign.
- Service-role loader reads `campaign_titles`/`campaigns` (both deny-all under RLS — no policy change). Dedupes by `title_id`, returns only `id/slug/title/poster_url + cpm_display`. Pool size, pool remaining, fee pct, settling days, partner identity, funded_at, and campaign ids stay server-side.

## Notes
- Homepage slot — the new `"active-campaigns"` slug is not yet in the `homepage_sections` CHECK constraint, so the section appears at the bottom of the homepage via the loader's missing-slug fallback. Repositioning is a follow-up migration; intentionally out of scope here.
- Optional `cpmDisplay` prop on `TitleCard` is unset everywhere except the new carousel; existing callers (Featured, All Films, search, profile top-12, lists) are unchanged.
- Untouched: campaign-metering, lifecycle transitions, funding RPCs, `creator_earnings`, RLS policies. No money-rail risk.

## What renders on prod
Today's funded/live campaigns all attach to **Erupcja** (one `live`, two `funded`, all CPM 250¢). After deploy:
- Homepage bottom section: one card, Erupcja poster, `$2.50 per 1,000 views` chip.
- `/t/erupcja`: "Active Campaign · Earn from your Edit" pill above the "Add yours →" link.
- Every other title page: unchanged.
- Homepage section is omitted entirely when no campaign is funded/live.

## Test plan
- [ ] Homepage — scroll to bottom section "Films you can earn from right now"; Erupcja card renders with the pink CPM chip top-right
- [ ] Erupcja card click routes to `/t/erupcja`
- [ ] `/t/erupcja` — pill renders above "Add yours →" for both logged-out and signed-in viewers
- [ ] A title without an active campaign (any other slug) — no pill, no visual change
- [ ] Spot-check search, `/lists/featured`, `/c/[handle]` — no regression from the optional `cpmDisplay` prop

🤖 Generated with [Claude Code](https://claude.com/claude-code)