### PR TITLE
campaigns discovery polish: rename + chrome pill + section repositioning

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,7 +61,7 @@ export default async function Home() {
     "active-campaigns": () =>
       activeCampaignTitles.length > 0 ? (
         <TitleCarousel
-          title="Films you can earn from right now"
+          title="Active Fan Edit Campaigns"
           titles={activeCampaignTitles.map((t) => ({
             id: t.id,
             slug: t.slug,

--- a/src/app/t/[slug]/page.tsx
+++ b/src/app/t/[slug]/page.tsx
@@ -236,26 +236,26 @@ export default async function TitlePage({ params }: PageProps) {
                 Distributed by {title.distributor}
               </p>
             )}
+            {/* Active-campaign pill — page chrome, not tab content.
+                Lives above the tab strip so creators landing on the
+                title page see the cue immediately without clicking
+                into Fan Edits. Server-component territory; the
+                hasActiveCampaign boolean is resolved in this file
+                via isTitleInActiveCampaign (service-role single-
+                title check, deny-all RLS bypass). Rendered for both
+                anon and signed-in viewers; gating is purely on
+                title, not auth. */}
+            {hasActiveCampaign ? (
+              <div className="inline-flex items-center gap-2 rounded-full bg-moonbeem-pink/15 px-3 py-1 text-body-sm font-medium text-moonbeem-pink">
+                Active Campaign · Earn from your Edit
+              </div>
+            ) : null}
           </div>
 
           <TitleTabs
             aboutContent={aboutContent}
             fanEditsContent={
               <>
-                {/* Active-campaign indicator. Rendered whenever the
-                    title sits in at least one funded-or-live
-                    campaign, regardless of viewer auth state — anon
-                    visitors see the same cue as signed-in creators
-                    and can act on it after signing up. The boolean
-                    comes from a service-role check
-                    (isTitleInActiveCampaign) because campaigns are
-                    deny-all under RLS; no campaign internals
-                    (pool, fee, partner, ids) cross the boundary. */}
-                {hasActiveCampaign ? (
-                  <div className="mb-4 inline-flex items-center gap-2 rounded-full bg-moonbeem-pink/15 px-3 py-1 text-body-sm font-medium text-moonbeem-pink">
-                    Active Campaign · Earn from your Edit
-                  </div>
-                ) : null}
                 {/* Block 3 entry point: signed-in viewers see a link
                     to /c/<their-handle>/upload?title_id=<this title>.
                     The upload page itself redirects to /me/edit?

--- a/src/lib/homepage-sections.ts
+++ b/src/lib/homepage-sections.ts
@@ -32,7 +32,7 @@ export const HOMEPAGE_SECTION_LABELS: Record<HomepageSectionSlug, string> = {
   trending: "Trending Edits",
   recent: "Recent Edits",
   "all-films": "All Films",
-  "active-campaigns": "Films you can earn from right now",
+  "active-campaigns": "Active Fan Edit Campaigns",
 };
 
 // Default order matches today's hardcoded JSX in src/app/page.tsx.

--- a/supabase/migrations/20260528000001_homepage_sections_active_campaigns.sql
+++ b/supabase/migrations/20260528000001_homepage_sections_active_campaigns.sql
@@ -1,0 +1,49 @@
+-- Extends homepage_sections.slug CHECK to include the creator-
+-- facing "Active Fan Edit Campaigns" carousel, then inserts the row
+-- positioned directly after Featured Films (display_order 3).
+-- Existing trending/recent/all-films rows shift down by one
+-- (3→4, 4→5, 5→6) to make room.
+--
+-- Original taxonomy + CHECK + seed lives in
+-- 20260526000004_homepage_sections.sql. Per the "future section
+-- addition (or rename) is a DROP-then-ADD constraint change"
+-- precedent noted there, this migration follows that pattern.
+--
+-- Curation admin at /admin/homepage already exposes drag-to-
+-- reorder via POST /api/admin/homepage/sections/reorder. The
+-- reorder API UPDATEs by slug, so an admin drag won't insert
+-- missing rows — this migration is required for the new section
+-- to land in the DB at all. Once landed, Dan can relocate freely
+-- from the curation UI.
+--
+-- Idempotent: the DO block runs the shift+insert only when no
+-- active-campaigns row exists yet. A re-apply (or a downstream
+-- environment where the row is already in place) is a no-op.
+
+alter table public.homepage_sections
+  drop constraint if exists homepage_sections_slug_check;
+
+alter table public.homepage_sections
+  add constraint homepage_sections_slug_check
+  check (slug in (
+    'marquee',
+    'featured',
+    'trending',
+    'recent',
+    'all-films',
+    'active-campaigns'
+  ));
+
+do $$
+begin
+  if not exists (
+    select 1 from public.homepage_sections where slug = 'active-campaigns'
+  ) then
+    update public.homepage_sections
+      set display_order = display_order + 1
+      where slug in ('trending', 'recent', 'all-films');
+
+    insert into public.homepage_sections (slug, display_order)
+      values ('active-campaigns', 3);
+  end if;
+end $$;


### PR DESCRIPTION
Two commits, three changes:

## 1. Carousel rename
`HOMEPAGE_SECTION_LABELS["active-campaigns"]` + the homepage renderer's `title` prop change from "Films you can earn from right now" → **"Active Fan Edit Campaigns"**. Vocabulary now matches homepage section + title-page pill + partner-side language. Slug unchanged; no DB rename needed.

## 2. Title-page pill moved to chrome
The pill previously lived inside `fanEditsContent`, so it only rendered after a click to the Fan Edits tab (TitleTabs is `"use client"`). Moved to the last child of the title-metadata block in `/t/[slug]/page.tsx` — server-rendered chrome, above the tab strip. SSR-curl will see "Active Campaign · Earn from your Edit" in the raw HTML. Visible to anon and signed-in viewers; gating is purely on title. The "Made a fan edit for this? Add yours →" CTA stays inside Fan Edits as the next-step action.

## 3. Section repositioning migration
`supabase/migrations/20260528000001_homepage_sections_active_campaigns.sql`:
- DROP + recreate the `slug` CHECK to include `"active-campaigns"`
- INSERT the row at `display_order = 3`, shift `trending`/`recent`/`all-films` down by one

Final order on the homepage: marquee → featured → active-campaigns → trending → recent → all-films.

The curation admin (`/admin/homepage` drag-to-reorder) is live, but its API UPDATEs by slug and doesn't insert — so the migration is required to land the row regardless. After this migration, the admin can freely reorder.

The migration body is wrapped in a DO block guarded on `NOT EXISTS (active-campaigns row)`, so re-applying is a no-op (no double-shift of downstream sections).

## What renders on prod after deploy + migration
- Homepage slot 3 (under Featured Films): "Active Fan Edit Campaigns" carousel, one Erupcja card with the $2.50 chip
- `/t/erupcja`: pill in the title-metadata block, immediately visible above the tab strip; no tab click needed
- Every other title page: no pill, no change
- `/search`, `/lists/*`, `/c/[handle]`, partner pages: untouched

## Money-rail / 3c safety
Zero contact with `campaign-metering`, `campaign_funding`, lifecycle, RPCs, RLS policies, `creator_earnings`, or any money rail. `homepage_sections` is a separate table with separate concerns.

## Test plan
- [ ] Homepage section order matches: marquee → featured → active-campaigns → trending → recent → all-films
- [ ] Erupcja card with $2.50 pill renders in slot 3
- [ ] `/t/erupcja` raw HTML contains "Active Campaign · Earn from your Edit" above tab strip (no tab click)
- [ ] Anon viewer + signed-in viewer both see the pill
- [ ] Title without active campaign — no pill
- [ ] `/admin/homepage` shows active-campaigns as a draggable row
- [ ] `/search`, `/lists/*`, `/c/[handle]` — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)