### PR TITLE
me: pending-edit progress copy + claim-stub merge button

### DIFF
--- a/src/app/api/me/stubs/[stubId]/claim/route.ts
+++ b/src/app/api/me/stubs/[stubId]/claim/route.ts
@@ -1,0 +1,80 @@
+// POST /api/me/stubs/[stubId]/claim — claim an orphan stub creator
+// surfaced in the "Edits to claim" section on /me. Delegates the
+// security gate entirely to the merge_stub_creator RPC
+// (20260528000002), which mirrors getUnclaimedStubEditsForUser's
+// match heuristics line-by-line. This route just adapts the RPC's
+// thrown-exception names into HTTP statuses + error JSON.
+
+import { NextResponse, type NextRequest } from "next/server";
+import { verifySession } from "@/lib/dal";
+import { createClient } from "@/lib/supabase/server";
+import { enforce } from "@/lib/ratelimit";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function POST(
+  _request: NextRequest,
+  context: { params: Promise<{ stubId: string }> },
+) {
+  const session = await verifySession();
+  const limit = await enforce(
+    "userWrites",
+    session.userId,
+    "me/stubs/claim",
+  );
+  if (!limit.ok) return limit.response;
+
+  const { stubId } = await context.params;
+  if (!UUID_RE.test(stubId)) {
+    return NextResponse.json({ error: "invalid_stub_id" }, { status: 400 });
+  }
+
+  // Cookie-based client so auth.uid() inside the SECURITY DEFINER RPC
+  // resolves to the caller. The RPC enforces the auth + ownership +
+  // heuristic-match checks itself; this route stays a thin adapter.
+  const supabase = await createClient();
+  const { error } = await supabase.rpc("merge_stub_creator", {
+    p_stub_creator_id: stubId,
+  });
+
+  if (error) {
+    const msg = error.message ?? "";
+    if (msg.includes("not_authenticated")) {
+      return NextResponse.json(
+        { error: "Not authenticated." },
+        { status: 401 },
+      );
+    }
+    if (msg.includes("no_creator_for_user")) {
+      return NextResponse.json(
+        { error: "Claim your handle before claiming edits." },
+        { status: 409 },
+      );
+    }
+    if (msg.includes("stub_not_claimable")) {
+      // Stub was already claimed by another transaction, or doesn't
+      // exist, or was soft-deleted. From the caller's perspective
+      // this means "the section's view of the world is stale" —
+      // a router.refresh() on the client clears it.
+      return NextResponse.json(
+        { error: "These edits are no longer available to claim." },
+        { status: 409 },
+      );
+    }
+    if (msg.includes("no_claim_match")) {
+      // Caller has no matching heuristic for this stub. Either the
+      // /me surface is showing them a stub they shouldn't see
+      // (a query bug worth fixing) or someone is calling the route
+      // directly with a stub_id they have no plausible tie to
+      // (the gate working as designed).
+      return NextResponse.json(
+        { error: "You can't claim this stub." },
+        { status: 403 },
+      );
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -604,15 +604,44 @@ export default async function MePage() {
           <div className="mt-3 border-t border-white/10 pt-3">
             {verifiedSocials.length === 0 && totalCents === 0
               ? (
-                <p className="text-body-sm text-moonbeem-ink-muted leading-relaxed m-0">
-                  When you create authorized fan edits, partners pay you for
-                  views and clicks through to their content. Earnings appear
-                  here once you&apos;ve verified a social handle and started
-                  getting attribution.
-                </p>
+                pendingSubmissions.length > 0 ? (
+                  // Pending-edit progress copy. Active when a creator
+                  // has zero earnings but at least one submission
+                  // awaiting admin review — replaces the passive
+                  // "When you create authorized fan edits…" empty-
+                  // state so the section acknowledges the work in
+                  // flight. The 24h response window is already shown
+                  // in the "Under review" section above, so this copy
+                  // stays earnings-focused and avoids duplicating it.
+                  <p className="text-body-sm text-moonbeem-ink-muted leading-relaxed m-0">
+                    {pendingSubmissions.length === 1
+                      ? "Your edit is under review. Earnings start the moment it's approved."
+                      : "Your edits are under review. Earnings start the moment they're approved."}
+                  </p>
+                ) : (
+                  <p className="text-body-sm text-moonbeem-ink-muted leading-relaxed m-0">
+                    When you create authorized fan edits, partners pay you for
+                    views and clicks through to their content. Earnings appear
+                    here once you&apos;ve verified a social handle and started
+                    getting attribution.
+                  </p>
+                )
               )
               : (
                 <div className="flex flex-col gap-4">
+                  {totalCents === 0 && pendingSubmissions.length > 0 && (
+                    // Same pending-edit progress copy as the empty-
+                    // state branch, surfaced ABOVE the $0.00 numbers
+                    // when a verified-social creator is waiting for
+                    // their first edit to be approved. Without this,
+                    // the populated dashboard shows just $0.00 with
+                    // no acknowledgment of the submission in flight.
+                    <p className="text-body-sm text-moonbeem-ink-muted leading-relaxed m-0">
+                      {pendingSubmissions.length === 1
+                        ? "Your edit is under review. Earnings start the moment it's approved."
+                        : "Your edits are under review. Earnings start the moment they're approved."}
+                    </p>
+                  )}
                   <div className="grid grid-cols-2 gap-4">
                     <div>
                       <div className="font-wordmark text-display-sm text-moonbeem-pink leading-none">

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/queries/titles";
 import { SignOutButton } from "@/components/SignOutButton";
 import PlatformIcon from "@/components/PlatformIcon";
+import ClaimStubButton from "@/components/me/ClaimStubButton";
 import PayoutsControls from "@/components/me/PayoutsControls";
 import WelcomeBanner from "@/components/me/WelcomeBanner";
 import ProfileFanEditCard from "@/components/profile/ProfileFanEditCard";
@@ -423,43 +424,70 @@ export default async function MePage() {
                 look like yours. Verify the handle to claim them.
               </p>
               <ul className="mt-4 flex flex-col gap-3">
-                {unclaimedStubs.map((stub) => (
-                  <li
-                    key={stub.stubCreatorId}
-                    className="flex items-center gap-3 rounded-md border border-white/10 bg-white/[0.02] p-3"
-                  >
-                    {stub.thumbnails.length > 0 ? (
-                      <div className="flex shrink-0 -space-x-2">
-                        {stub.thumbnails.slice(0, 3).map((src, i) => (
-                          // eslint-disable-next-line @next/next/no-img-element
-                          <img
-                            key={src}
-                            src={src}
-                            alt=""
-                            width={40}
-                            height={40}
-                            className="h-10 w-10 rounded-md border border-white/15 bg-black/40 object-cover"
-                            style={{ zIndex: 3 - i }}
-                          />
-                        ))}
-                      </div>
-                    ) : null}
-                    <div className="min-w-0 flex-1">
-                      <p className="m-0 text-body-sm text-moonbeem-ink">
-                        {stub.fanEditCount} edit
-                        {stub.fanEditCount === 1 ? "" : "s"} as @
-                        {stub.socialHandle} on{" "}
-                        {platformLabel[stub.platform as SocialPlatform]}
-                      </p>
-                    </div>
-                    <Link
-                      href={`/me/edit?return_to=${encodeURIComponent("/me")}&platform=${stub.platform}&handle=${encodeURIComponent(stub.socialHandle)}`}
-                      className="shrink-0 text-body-sm text-moonbeem-pink hover:opacity-90"
+                {unclaimedStubs.map((stub) => {
+                  // CTA selection. The verify-then-merge flow at
+                  // /me/edit only works when (a) the surface tied the
+                  // stub to a handle the user could still verify on
+                  // a not-yet-verified platform AND (b) the
+                  // verification's exact (platform, lower(handle))
+                  // lookup will hit the stub's social row. Heuristic
+                  // (a) — user_handle — only satisfies that when the
+                  // user hasn't verified the same platform under any
+                  // other handle (otherwise VerifySocialsCard
+                  // silently skips and dead-ends). Heuristic (b) —
+                  // verified_social — implies the user already
+                  // verified the platform, so verify-to-claim always
+                  // dead-ends there. The Claim button calls the new
+                  // merge_stub_creator RPC directly and works for
+                  // both heuristics.
+                  const platformAlreadyVerified = verifiedSocials.some(
+                    (v) => v.platform === stub.platform,
+                  );
+                  const useVerifyLink =
+                    stub.matchType === "user_handle" &&
+                    !platformAlreadyVerified;
+                  return (
+                    <li
+                      key={stub.stubCreatorId}
+                      className="flex items-center gap-3 rounded-md border border-white/10 bg-white/[0.02] p-3"
                     >
-                      Verify to claim →
-                    </Link>
-                  </li>
-                ))}
+                      {stub.thumbnails.length > 0 ? (
+                        <div className="flex shrink-0 -space-x-2">
+                          {stub.thumbnails.slice(0, 3).map((src, i) => (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                              key={src}
+                              src={src}
+                              alt=""
+                              width={40}
+                              height={40}
+                              className="h-10 w-10 rounded-md border border-white/15 bg-black/40 object-cover"
+                              style={{ zIndex: 3 - i }}
+                            />
+                          ))}
+                        </div>
+                      ) : null}
+                      <div className="min-w-0 flex-1">
+                        <p className="m-0 text-body-sm text-moonbeem-ink">
+                          {stub.fanEditCount} edit
+                          {stub.fanEditCount === 1 ? "" : "s"} as @
+                          {stub.socialHandle} on{" "}
+                          {platformLabel[stub.platform as SocialPlatform]}
+                        </p>
+                      </div>
+                      {useVerifyLink ? (
+                        <Link
+                          href={`/me/edit?return_to=${encodeURIComponent("/me")}&platform=${stub.platform}&handle=${encodeURIComponent(stub.socialHandle)}`}
+                          className="shrink-0 text-body-sm text-moonbeem-pink hover:opacity-90"
+                        >
+                          Verify to claim →
+                        </Link>
+                      ) : (
+                        <ClaimStubButton stubCreatorId={stub.stubCreatorId} />
+                      )}
+                    </li>
+                  );
+                })}
               </ul>
             </div>
           </section>

--- a/src/components/me/ClaimStubButton.tsx
+++ b/src/components/me/ClaimStubButton.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+// Claim button for the /me "Edits to claim" section. POSTs to the
+// merge_stub_creator API route, which runs the security gate inside
+// the SECURITY DEFINER RPC. On success router.refresh() re-renders
+// the server component; the stub disappears from the section because
+// its creators.deleted_at is now set and
+// getUnclaimedStubEditsForUser filters it out.
+//
+// Replaces the previous "Verify to claim →" Link for stubs surfaced
+// by the verified_social heuristic AND for user_handle-surfaced
+// stubs where the caller has already verified that platform (the
+// case where the verify-then-merge flow silently dead-ends because
+// VerifySocialsCard skips already-verified platforms).
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  fetchJson,
+  FetchJsonError,
+  RateLimitedError,
+} from "@/lib/fetch-json";
+
+type Props = {
+  stubCreatorId: string;
+};
+
+export default function ClaimStubButton({ stubCreatorId }: Props) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  async function handleClick() {
+    setPending(true);
+    setErrorMsg(null);
+    try {
+      await fetchJson(`/api/me/stubs/${stubCreatorId}/claim`, {
+        method: "POST",
+      });
+      router.refresh();
+    } catch (err) {
+      setErrorMsg(
+        err instanceof RateLimitedError || err instanceof FetchJsonError
+          ? err.userMessage
+          : err instanceof Error
+            ? err.message
+            : String(err),
+      );
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="flex shrink-0 flex-col items-end gap-1">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={pending}
+        className="text-body-sm text-moonbeem-pink hover:opacity-90 disabled:opacity-50"
+      >
+        {pending ? "Claiming…" : "Claim these edits"}
+      </button>
+      {errorMsg && (
+        <p className="m-0 text-caption text-moonbeem-magenta">{errorMsg}</p>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/20260528000002_merge_stub_creator.sql
+++ b/supabase/migrations/20260528000002_merge_stub_creator.sql
@@ -1,0 +1,200 @@
+-- Caller-driven claim of an orphan stub creator.
+--
+-- Background. Stub creators (is_stub=true, user_id IS NULL) are
+-- minted by find_or_create_stub_creator (20260506000007) during
+-- admin/CSV imports so attribution lands somewhere even when the
+-- handle on the source URL doesn't match any real account yet.
+-- mark_social_verified_and_merge (20260508000001 + 20260508000004)
+-- folds a stub into a real user when verification finds an EXACT
+-- (platform, lower(handle)) match between the verifying user and the
+-- stub's creator_socials row.
+--
+-- The /me "Edits to claim" section surfaces a wider set of stubs via
+-- getUnclaimedStubEditsForUser (src/lib/queries/profiles.ts:199-360),
+-- which adds NORMALIZED-handle and platform-scoped verified-social
+-- heuristics. For stubs surfaced by normalize-only matches, the
+-- existing verification flow can't claim them — start_social_-
+-- verification keys on EXACT (platform, lower(handle)), so a stub
+-- with handle "duolingo_polska" never lines up with a user verifying
+-- "duolingopolska". And once a user has any verified social on a
+-- platform, VerifySocialsCard silently skips rendering for that
+-- platform, so the "Verify to claim →" CTA dead-ends.
+--
+-- This RPC is the explicit one-click claim for those cases.
+--
+-- SECURITY. The caller passes a stub_creator_id and asks to claim it.
+-- The auth gate has to mirror getUnclaimedStubEditsForUser EXACTLY,
+-- because that query is the surfacing decision the UI uses to decide
+-- which stubs to show a Claim button on. If the RPC accepts a match
+-- that surfacing didn't, an authenticated user can claim a stub they
+-- have no plausible tie to (security hole). If the RPC rejects a
+-- match that surfacing accepted, the UI offers a button that errors
+-- out (UX bug + erosion of trust). The two heuristics in step 3 below
+-- are line-by-line equivalents of profiles.ts:282-310 — keep them in
+-- lockstep with that file.
+--
+-- Merge body in step 4 mirrors mark_social_verified_and_merge
+-- (20260508000001) and the creator_earnings move from
+-- 20260508000004. The dup-skip pattern on creator_earnings is
+-- preserved verbatim from the precedent.
+
+-- Comparison-normalization for handles: lowercase + strip
+-- underscores, dots, whitespace. Mirrors the JS normalize() at
+-- profiles.ts:242 exactly. Used by both the security gate below and
+-- (going forward, when we DRY profiles.ts onto this) the surfacing
+-- query. If you change this function you MUST change the JS
+-- normalize() the same way or the gate and the surface disagree.
+create or replace function public.normalize_handle_for_match(h text)
+returns text
+language sql
+immutable
+as $$
+  select regexp_replace(lower(coalesce(h, '')), '[_.[:space:]]', '', 'g');
+$$;
+
+revoke execute on function public.normalize_handle_for_match(text) from public;
+grant execute on function public.normalize_handle_for_match(text) to authenticated;
+
+create or replace function public.merge_stub_creator(
+  p_stub_creator_id uuid
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_user_creator_id uuid;
+  v_user_moonbeem_handle text;
+  v_stub creators%rowtype;
+  v_match_exists boolean := false;
+begin
+  -- 1. Caller must be authenticated and own a live creator row. A
+  --    user with no creator row hasn't been through claim_handle yet
+  --    and has nothing to merge a stub into.
+  if v_user_id is null then
+    raise exception 'not_authenticated';
+  end if;
+
+  select id, moonbeem_handle
+    into v_user_creator_id, v_user_moonbeem_handle
+    from public.creators
+    where user_id = v_user_id and deleted_at is null
+    limit 1;
+
+  if v_user_creator_id is null then
+    raise exception 'no_creator_for_user';
+  end if;
+
+  -- 2. Target must be a live, unclaimed stub. FOR UPDATE serializes
+  --    concurrent claim attempts on the same stub — last writer
+  --    can't reanimate a row another transaction already merged and
+  --    soft-deleted because the second SELECT FOR UPDATE blocks
+  --    until the first commits, and then v_stub.id comes back NULL
+  --    (deleted_at is set) and we raise stub_not_claimable.
+  select * into v_stub
+    from public.creators
+    where id = p_stub_creator_id
+      and is_stub = true
+      and user_id is null
+      and deleted_at is null
+    for update;
+
+  if v_stub.id is null then
+    raise exception 'stub_not_claimable';
+  end if;
+
+  -- 3. THE SECURITY CHECK. Mirrors profiles.ts:282-310 exactly.
+  --
+  --    Heuristic (a) — user_handle: the stub has at least one
+  --    creator_socials row on an allowed platform whose handle
+  --    normalizes to the caller's moonbeem_handle. (profiles.ts:301
+  --    `} else if (normH === normalizedUserHandle) {`.) The
+  --    platform-in-allowed-list filter mirrors profiles.ts:284-288.
+  if v_user_moonbeem_handle is not null then
+    select true into v_match_exists
+      from public.creator_socials cs
+      where cs.creator_id = p_stub_creator_id
+        and cs.platform in ('tiktok','instagram','twitter','youtube')
+        and cs.handle is not null
+        and public.normalize_handle_for_match(cs.handle)
+            = public.normalize_handle_for_match(v_user_moonbeem_handle)
+      limit 1;
+  end if;
+
+  --    Heuristic (b) — verified_social: the caller has a verified
+  --    creator_socials row on platform P, and the stub has a
+  --    creator_socials row on the same platform P where the two
+  --    handles agree under lower() OR normalize_handle_for_match().
+  --    (profiles.ts:294-300; the dual lower-OR-normalize check
+  --    mirrors `platformVerified.exact.has(...) || platformVerified.
+  --    normalized.has(normH)` exactly.) Platform scoping is
+  --    load-bearing here — @dansickles on TikTok and @dansickles on
+  --    Twitter could be different humans, and the surfacing query
+  --    treats them as separate; the gate has to as well.
+  if v_match_exists is not true then
+    select true into v_match_exists
+      from public.creator_socials cs_user
+      inner join public.creator_socials cs_stub
+        on cs_user.platform = cs_stub.platform
+        and (
+          lower(cs_user.handle) = lower(cs_stub.handle)
+          or public.normalize_handle_for_match(cs_user.handle)
+             = public.normalize_handle_for_match(cs_stub.handle)
+        )
+      where cs_user.creator_id = v_user_creator_id
+        and cs_user.verified_at is not null
+        and cs_user.handle is not null
+        and cs_stub.creator_id = p_stub_creator_id
+        and cs_stub.handle is not null
+        and cs_stub.platform in ('tiktok','instagram','twitter','youtube')
+      limit 1;
+  end if;
+
+  if v_match_exists is not true then
+    raise exception 'no_claim_match';
+  end if;
+
+  -- 4. Merge body — mirrors mark_social_verified_and_merge body
+  --    (20260508000001:170-182) + creator_earnings handling from
+  --    20260508000004.
+
+  update public.creator_socials
+    set creator_id = v_user_creator_id
+    where creator_id = p_stub_creator_id;
+
+  update public.fan_edits
+    set creator_id = v_user_creator_id
+    where creator_id = p_stub_creator_id;
+
+  -- creator_earnings: move to caller, flip claimed=true. Dup-skip
+  -- preserves any pre-existing earnings row the caller already had
+  -- for the same (fan_edit_id, calculation_date) — shouldn't happen
+  -- for a never-claimed stub but the guard matches the precedent and
+  -- is cheap.
+  update public.creator_earnings
+    set creator_id = v_user_creator_id,
+        claimed = true
+    where creator_id = p_stub_creator_id
+      and not exists (
+        select 1 from public.creator_earnings dup
+        where dup.creator_id = v_user_creator_id
+          and dup.fan_edit_id = creator_earnings.fan_edit_id
+          and dup.calculation_date = creator_earnings.calculation_date
+      );
+  delete from public.creator_earnings
+    where creator_id = p_stub_creator_id;
+
+  -- 5. Soft-delete the stub. Once deleted_at is set the stub no
+  --    longer surfaces via getUnclaimedStubEditsForUser (its
+  --    creators.deleted_at IS NULL filter, profiles.ts:267), so the
+  --    "Edits to claim" entry vanishes on the next /me load.
+  update public.creators
+    set deleted_at = now()
+    where id = p_stub_creator_id and deleted_at is null;
+end;
+$$;
+
+revoke execute on function public.merge_stub_creator(uuid) from public;
+grant execute on function public.merge_stub_creator(uuid) to authenticated;


### PR DESCRIPTION
Two-commit slice. Closes the creator-onboarding-recon's "Pre-onboarding nice-to-haves" + the recommended next slice for orphan-stub recovery.

## Commit 1 — `me: pending-edit progress copy in both empty-state and $0.00 dashboard`
Earnings section on /me now shows progress copy when `totalCents === 0 && pendingSubmissions.length > 0`:
- Empty-state branch (no verified social, no earnings) — swaps the passive copy for "Your edit(s) under review. Earnings start the moment it's/they're approved."
- Populated $0.00 dashboard branch (verified social, no earnings yet) — adds the same progress line above the $0.00 numbers.

Common-case onboarding scenario (self-serve creator, verified social, first submission in review) is now acknowledged in the earnings section. `pendingSubmissions` already in scope; no new data fetching. The 24-hour response window is already announced in the "Under review" section directly above; this copy stays earnings-focused to avoid duplication.

## Commit 2 — `claim-stub merge RPC + button: enable orphan stub recovery via /me`
**Background**: stubs surfaced via `getUnclaimedStubEditsForUser`'s `verified_social` heuristic, OR via `user_handle` when the user has already verified that platform, were dead-ends. `VerifySocialsCard` silently skips already-verified platforms, so the "Verify to claim →" CTA went nowhere.

**Fix**: explicit one-click claim path.

- **`merge_stub_creator(stub_id)` RPC** — security-definer, mirrors `mark_social_verified_and_merge`'s merge body. Heuristic auth gate is line-by-line equivalent of `profiles.ts:282-310`:
  - (a) user_handle: stub creator_social on allowed platform with normalize_handle_for_match(handle) = normalize_handle_for_match(caller.moonbeem_handle)
  - (b) verified_social: caller's verified social JOIN stub social on same platform, lower-OR-normalize handle equality
  - Mismatch → `no_claim_match`. Auth/ownership/claimable checks fire first.
- **`normalize_handle_for_match(text)`** — new shared SQL helper that mirrors the JS `normalize()` at `profiles.ts:242`. Single source of truth for handle comparison normalization going forward.
- **POST `/api/me/stubs/[stubId]/claim`** — thin adapter. UUID regex check, verifySession, rate limit, cookie-client RPC. Maps RPC exceptions to HTTP statuses.
- **`ClaimStubButton`** + `/me` CTA selector. Preserves the existing "Verify to claim →" link for `user_handle` matches where the platform isn't verified yet (verification still does both verify AND merge). Every other case routes to the Claim button.

## Apply order
1. Merge --rebase (Vercel deploys code; RPC + button errored-but-not-clicked until step 3).
2. Apply migration `20260528000002_merge_stub_creator.sql` via `mcp__plugin_supabase_supabase__apply_migration`. Vercel does NOT auto-apply Supabase migrations.
3. Verify on prod per checklist below.

## Money-rail / 3c safety
Zero contact with `campaign-metering`, `campaign_funding`, lifecycle, RPCs in the metering family, RLS policies on campaigns, or any money rail. The merge RPC touches `creator_socials`, `fan_edits`, `creator_earnings`, and `creators` — and only to migrate ownership of rows already owned by a stub, exactly as `mark_social_verified_and_merge` does today.

## Test plan
- [ ] Fix 1: a creator with `verifiedSocials > 0`, `totalCents === 0`, ≥1 pending edit — progress copy shows above $0.00 numbers
- [ ] Fix 1: a creator with `verifiedSocials === 0`, `totalCents === 0`, ≥1 pending edit — empty-state version of progress copy shows
- [ ] Fix 1: a creator with `verifiedSocials === 0`, `totalCents === 0`, 0 pending — original "When you create authorized…" copy shows
- [ ] Fix 2 happy path: stub matching a test account via handle-similarity OR verified-social — Claim button renders, click claims, section refreshes, stub disappears, stub's fan_edits + earnings now on user's row, stub creators row soft-deleted
- [ ] Fix 2 verify-path preserved: stub with `matchType === "user_handle"` for a test account that hasn't verified the platform — "Verify to claim →" link still renders (not the button), completing verification still merges via Path 2
- [ ] Fix 2 security: curl `POST /api/me/stubs/<unrelated-uuid>/claim` as authed user → 403 `no_claim_match`
- [ ] Fix 2 security: curl with non-UUID stubId → 400 `invalid_stub_id`
- [ ] Fix 2 security: curl unauthenticated → 401
- [ ] Fix 2 security: curl with an already-claimed/soft-deleted stub → 409 `stub_not_claimable`
- [ ] No regression: /search, /lists/*, /c/[handle], partner pages, homepage — visual spot-check unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)