### PR TITLE
money-rail: integer largest-remainder prorata (drains to exact zero) + decouple void from completion

### DIFF
--- a/supabase/functions/campaign-metering/index.ts
+++ b/supabase/functions/campaign-metering/index.ts
@@ -155,6 +155,10 @@ type SettledRow = {
   id: string;
   fan_edit_id: string;
   full_cpm_cents: number;
+  // appeared_at is the deterministic secondary tiebreak (after
+  // remainder) for largest-remainder leftover-cent assignment, and
+  // the FIFO order the select already imposes.
+  appeared_at: string;
 };
 
 type FanEditMeta = { creator_id: string | null; title_id: string };
@@ -514,7 +518,7 @@ async function pass2BillSettled(
   // appeared_at first (FIFO within the campaign).
   const { data: settled, error } = await supabase
     .from("campaign_metering_deltas")
-    .select("id, fan_edit_id, full_cpm_cents")
+    .select("id, fan_edit_id, full_cpm_cents, appeared_at")
     .eq("campaign_id", campaign.id)
     .eq("status", "settled")
     .gt("full_cpm_cents", 0)
@@ -572,32 +576,92 @@ async function pass2BillSettled(
   const fanEditIds = Array.from(new Set(rows.map((r) => r.fan_edit_id)));
   const fanEdits = await fetchFanEditMeta(supabase, fanEditIds);
 
+  // ---- PASS 1: compute the authoritative per-delta billed amount ----
+  // No writes here. The amount source is now integer-exact, never a
+  // JS-double factor:
+  //   Full-CPM run (factor === null): each delta bills its exact
+  //   integer full_cpm. No apportionment, no flooring — identical to
+  //   the prior full-CPM behavior, just routed through the explicit
+  //   p_billed_cents param.
+  //   Pro-rata run: integer largest-remainder (Hamilton) apportionment
+  //   of the pool across the settled set, so Σ billed === pool EXACTLY.
+  //   This eliminates the floor() residue that used to wedge the pool a
+  //   few cents above zero and make strict-zero completion unreachable.
+  const finalCentsById = new Map<string, number>();
+
+  if (!isProrata) {
+    for (const row of rows) {
+      finalCentsById.set(row.id, row.full_cpm_cents);
+    }
+  } else {
+    // Integer arithmetic throughout — no JS-double factor touches the
+    // money. Magnitude safety: poolBefore is bounded by realistic pool
+    // sizes (≤ ~10^7 cents) and full_cpm_cents by per-delta CPM earnings
+    // (≤ ~10^6 cents), so numer = poolBefore * full_cpm_cents stays well
+    // under Number.MAX_SAFE_INTEGER (9.007×10^15). totalWanted > 0 here
+    // (isProrata implies totalWanted > poolBefore ≥ 1).
+    const apportioned = rows.map((row) => {
+      const numer = poolBefore * row.full_cpm_cents;
+      const floorCents = Math.floor(numer / totalWanted);
+      const remainder = numer - floorCents * totalWanted; // numer mod totalWanted
+      return { row, floorCents, remainder };
+    });
+
+    const allocated = apportioned.reduce((s, a) => s + a.floorCents, 0);
+    const leftover = poolBefore - allocated; // proven: 0 ≤ leftover < N
+
+    // Deterministic leftover-cent assignment: highest remainder first,
+    // then FIFO (appeared_at ASC), then id ASC. Sort a COPY — PASS 2
+    // writes in the original FIFO order. Determinism makes a retried
+    // run reproduce the same assignment for the same settled set.
+    const byRemainder = [...apportioned].sort((a, b) => {
+      if (b.remainder !== a.remainder) return b.remainder - a.remainder;
+      if (a.row.appeared_at !== b.row.appeared_at) {
+        return a.row.appeared_at < b.row.appeared_at ? -1 : 1;
+      }
+      return a.row.id < b.row.id ? -1 : a.row.id > b.row.id ? 1 : 0;
+    });
+
+    for (const a of apportioned) finalCentsById.set(a.row.id, a.floorCents);
+    for (let i = 0; i < leftover && i < byRemainder.length; i++) {
+      const a = byRemainder[i];
+      finalCentsById.set(a.row.id, a.floorCents + 1);
+    }
+
+    // Invariant: Σ final === pool EXACTLY. A violation means an
+    // apportionment bug; bail the run safely (write NOTHING) rather
+    // than bill wrong amounts on the money rail. The fatal-catch flips
+    // the run to 'failed' and leaves all deltas 'settled' for retry.
+    const finalSum = rows.reduce(
+      (s, r) => s + (finalCentsById.get(r.id) ?? 0),
+      0,
+    );
+    if (finalSum !== poolBefore) {
+      throw new Error(
+        `largest-remainder invariant violated: Σfinal=${finalSum} != pool=${poolBefore} (totalWanted=${totalWanted}, leftover=${leftover}, rows=${rows.length})`,
+      );
+    }
+  }
+
+  // ---- PASS 2: write, in original FIFO order ----
+  // poolRemaining is a logging/tracker mirror only — it is NO LONGER
+  // the money source and NO LONGER gates anything (void is decoupled
+  // and keyed off the authoritative ledger SUM in the handler).
   let poolRemaining = poolBefore;
   let rowsBilled = 0;
   let totalBilledCents = 0;
-  let poolExhausted = false;
   let rowsSkippedRounding = 0;
   let rowsSkippedOrphan = 0;
   const rpcErrors: Array<{ delta_id: string; error: string }> = [];
 
   for (const row of rows) {
-    // Defensive — should not trigger in normal pro-rata math
-    // (floor() leaves a few cents in the pool), but if the pool
-    // somehow hits 0 mid-loop, stop and void the rest.
-    if (poolRemaining <= 0) {
-      poolExhausted = true;
-      break;
-    }
-
-    const billedCents = Math.floor(row.full_cpm_cents * factorForRpc);
+    const billedCents = finalCentsById.get(row.id) ?? 0;
     if (billedCents <= 0) {
-      // Sub-row rounded to 0 (small full_cpm under a tiny factor).
-      // Skip — the RPC would raise 'prorata_yields_zero'. The row
-      // stays 'settled' until the next run or 3c.3 voids it.
+      // Pro-rata floor rounded this delta to 0 and it did not win a
+      // leftover cent. Skip — it stays 'settled' and is voided when the
+      // campaign completes (ledger SUM === 0). On full-CPM runs this
+      // never happens: the select filters full_cpm_cents > 0.
       rowsSkippedRounding += 1;
-      console.warn(
-        `[campaign-metering] skipping delta=${row.id}: floor(${row.full_cpm_cents} * ${factorForRpc}) <= 0`,
-      );
       continue;
     }
 
@@ -624,6 +688,7 @@ async function pass2BillSettled(
           p_metering_delta_id: row.id,
           p_prorata_run_id: runId,
           p_prorata_factor: factorForRpc,
+          p_billed_cents: billedCents,
           p_creator_id: fe.creator_id,
           p_partner_id: campaign.partner_id,
           p_title_id: fe.title_id,
@@ -644,6 +709,10 @@ async function pass2BillSettled(
       // single bad row.
     }
   }
+
+  // Informational only — the handler gates completion AND void on the
+  // authoritative ledger SUM, not on this tracker.
+  const poolExhausted = poolRemaining <= 0;
 
   return {
     rowsBilled,
@@ -882,29 +951,37 @@ Deno.serve(async (_req: Request) => {
       `[campaign-metering] Pass 2: rows_billed=${result.rowsBilled} total_billed_cents=${result.totalBilledCents} factor=${result.factor} pool_after=${result.poolAfter} exhausted=${result.poolExhausted} skipped_rounding=${result.rowsSkippedRounding} skipped_orphan=${result.rowsSkippedOrphan} rpc_errors=${result.rpcErrors.length}`,
     );
 
-    let rowsVoided = 0;
-    if (result.poolExhausted) {
-      rowsVoided = await voidRemainingSettled(
-        supabase,
-        target.campaign.id,
-        runId,
-      );
-      console.log(
-        `[campaign-metering] pool exhausted; voided ${rowsVoided} remaining settled rows`,
-      );
-    }
-
     // Authoritative pool — re-read from the campaign_ledger SUM
     // after all the run's writes have landed. The in-loop
-    // result.poolAfter is a JS-tracker mirror used only for the
-    // mid-loop "should we stop and void?" defense; the value
-    // recorded on the run row and reported in the response is
+    // result.poolAfter is a JS-tracker mirror (logging only); the
+    // value recorded on the run row and reported in the response is
     // the ledger truth, so floor-rounding cents or tracker drift
     // never leak into reporting.
     const poolAfter = await campaignPoolRemaining(
       supabase,
       target.campaign.id,
     );
+
+    // Void any remaining 'settled' rows once the pool is fully drained.
+    // Gated on the authoritative ledger SUM (poolAfter === 0) — the
+    // SAME condition that fires completion below — so completion and
+    // void always happen together. (Previously gated on the mid-loop
+    // poolExhausted tracker, which could miss when the cent-bearing row
+    // was last or when rows billed 0, leaving settled stragglers
+    // against a drained pool.) voidRemainingSettled is idempotent and
+    // voids ALL status='settled' rows for the campaign, cleaning the
+    // zero-billed and full_cpm=0 stragglers in one shot.
+    let rowsVoided = 0;
+    if (poolAfter === 0) {
+      rowsVoided = await voidRemainingSettled(
+        supabase,
+        target.campaign.id,
+        runId,
+      );
+      console.log(
+        `[campaign-metering] pool drained (ledger SUM=0); voided ${rowsVoided} remaining settled rows`,
+      );
+    }
 
     // Lifecycle transitions (3c.3) — funded -> live on first
     // billing, live -> completed on pool == 0. Runs AFTER the

--- a/supabase/migrations/20260604000001_bill_settled_delta_explicit_amount.sql
+++ b/supabase/migrations/20260604000001_bill_settled_delta_explicit_amount.sql
@@ -1,0 +1,233 @@
+-- Money-rail fix, commit (i): bill_settled_delta takes an explicit
+-- p_billed_cents amount instead of recomputing floor(full_cpm × factor).
+--
+-- WHY
+--   The 3c.2 metering job billed each delta at floor(full_cpm ×
+--   prorata_factor). floor() systematically under-bills, leaving a
+--   sub-cent-per-row residue that accumulated and wedged the pool a few
+--   cents above zero — making the strict-zero completion condition
+--   (campaign-metering applyLifecycleTransitions, pool === 0)
+--   unreachable. Campaign e8150462 froze at 1¢ with 523 settled deltas.
+--
+--   The fix moves the apportionment up into the Edge Function, which now
+--   computes an integer largest-remainder (Hamilton) distribution of the
+--   pool across the settled set so Σ billed === pool EXACTLY, and passes
+--   each delta's authoritative amount here. This RPC no longer derives
+--   the money from the factor; it bills exactly what it is handed.
+--
+-- WHAT CHANGES (the ONLY behavioral change)
+--   - New parameter p_billed_cents integer — the authoritative amount.
+--   - v_billed_cents is now p_billed_cents, not floor(v_md_full_cpm ×
+--     p_prorata_factor). The internal recompute is removed.
+--   - p_prorata_factor is RETAINED but used ONLY to stamp the delta's
+--     prorata_factor (audit), never for money.
+--
+-- WHAT IS PRESERVED EXACTLY (every other behavior — line-for-line)
+--   - the SELECT … FOR UPDATE OF md, c lock
+--   - idempotent already-'billed' replay (returns existing earning)
+--   - the v_md_status / v_campaign_status / p_prorata_factor guards and
+--     every RAISE path (unknown_metering_delta, invalid_metering_delta_
+--     state, invalid_campaign_state, invalid_prorata_factor,
+--     prorata_yields_zero, unknown_snapshot, unknown_creator,
+--     earning_already_withdrawn)
+--   - views_at_calculation sourced from the delta's own snapshot
+--   - the day-keyed ON CONFLICT (creator_id, fan_edit_id,
+--     calculation_date, campaign_id) accumulation:
+--     earnings_cents = earnings_cents + excluded.earnings_cents, with the
+--     withdrawn_at IS NULL guard
+--   - exactly one campaign_ledger 'payout' debit per delta,
+--     amount_cents = -v_billed_cents, creator_earning_id FK set
+--   - the delta flip to 'billed' + prorata_run_id / prorata_factor stamps
+--   - the service-role-only lockdown (REVOKE … FROM public, anon,
+--     authenticated; GRANT EXECUTE TO service_role)
+--
+-- SIGNATURE CHANGE ⇒ DROP then CREATE
+--   Adding a parameter changes the function signature; CREATE OR REPLACE
+--   would leave the old 6-arg overload in place alongside the new 7-arg
+--   one (two callable functions). DROP the old signature first so only
+--   the new one exists. The DROP is signature-qualified to the OLD
+--   6-arg form.
+
+-- ---------------------------------------------------------------
+-- 1. Drop the old 6-arg signature.
+-- ---------------------------------------------------------------
+drop function if exists public.bill_settled_delta(
+  uuid, uuid, numeric, uuid, uuid, uuid
+);
+
+-- ---------------------------------------------------------------
+-- 2. The RPC, with p_billed_cents.
+-- ---------------------------------------------------------------
+
+create or replace function public.bill_settled_delta(
+  p_metering_delta_id uuid,
+  p_prorata_run_id uuid,
+  p_prorata_factor numeric,
+  p_billed_cents integer,
+  p_creator_id uuid,
+  p_partner_id uuid,
+  p_title_id uuid
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_md_status text;
+  v_md_full_cpm integer;
+  v_md_campaign_id uuid;
+  v_md_fan_edit_id uuid;
+  v_md_snapshot_id uuid;
+  v_md_existing_earning uuid;
+  v_campaign_status text;
+  v_is_stub boolean;
+  v_billed_cents integer;
+  v_views integer;
+  v_earning_id uuid;
+begin
+  -- Lock the metering delta and its campaign in one statement.
+  select md.status, md.full_cpm_cents, md.campaign_id,
+         md.fan_edit_id, md.snapshot_id, md.creator_earning_id,
+         c.status
+    into v_md_status, v_md_full_cpm, v_md_campaign_id,
+         v_md_fan_edit_id, v_md_snapshot_id, v_md_existing_earning,
+         v_campaign_status
+    from public.campaign_metering_deltas md
+    join public.campaigns c on c.id = md.campaign_id
+    where md.id = p_metering_delta_id
+    for update of md, c;
+
+  if not found then
+    raise exception 'unknown_metering_delta';
+  end if;
+
+  -- Idempotent same-row replay: this delta is already billed.
+  if v_md_status = 'billed' then
+    return v_md_existing_earning;
+  end if;
+
+  if v_md_status <> 'settled' then
+    raise exception 'invalid_metering_delta_state';
+  end if;
+
+  if v_campaign_status not in ('funded', 'live') then
+    raise exception 'invalid_campaign_state';
+  end if;
+
+  if p_prorata_factor is null or
+     p_prorata_factor <= 0 or
+     p_prorata_factor > 1 then
+    raise exception 'invalid_prorata_factor';
+  end if;
+
+  -- The caller (Edge Function Pass 1) supplies the authoritative
+  -- amount via largest-remainder apportionment. We no longer recompute
+  -- from the factor. The positivity guard is retained (same
+  -- 'prorata_yields_zero' contract): the caller skips deltas whose
+  -- apportioned amount is 0, so reaching here with <= 0 is a caller
+  -- bug, raised loudly rather than billed.
+  v_billed_cents := p_billed_cents;
+  if v_billed_cents is null or v_billed_cents <= 0 then
+    raise exception 'prorata_yields_zero';
+  end if;
+
+  -- Source views_at_calculation from the actual snapshot this
+  -- delta represents — the precise view count at the moment the
+  -- delta appeared, not the current denormalized
+  -- fan_edits.view_count.
+  select view_count
+    into v_views
+    from public.view_tracking_snapshots
+    where id = v_md_snapshot_id;
+
+  if v_views is null then
+    raise exception 'unknown_snapshot';
+  end if;
+
+  -- Look up creator stub status for `claimed` (mirrors legacy
+  -- earnings-calc.ts semantics: claimed=true for real creators,
+  -- false for stubs; legacy treats NULL is_stub as real via the
+  -- `!!c.is_stub` coercion, mirrored here by coalesce(..., false)).
+  -- Missing creator row is a defensive error — the Edge Function
+  -- should never call with a stranger creator_id.
+  select is_stub
+    into v_is_stub
+    from public.creators
+    where id = p_creator_id;
+
+  if not found then
+    raise exception 'unknown_creator';
+  end if;
+
+  -- INSERT-or-accumulate on the day-keyed unique index. Two
+  -- metering deltas on the same UTC day for the same
+  -- (creator, fan_edit, campaign) aggregate into one earnings row.
+  -- Each delta's earning is summed in; each delta still writes its
+  -- own campaign_ledger debit and stamps its own creator_earning_id
+  -- back. The earning<->delta relation is 1-to-many on collision
+  -- days; this is schema-legal (the FK on
+  -- campaign_metering_deltas.creator_earning_id is not unique). On
+  -- collision, views_at_calculation is updated to the more recent
+  -- snapshot's view count (the later delta's snapshot is the more
+  -- current truth of "where we are today").
+  --
+  -- The DO UPDATE WHERE guards against a manual same-day re-trigger
+  -- after a creator has withdrawn the day-row: if withdrawn_at is
+  -- already set, the update is silently skipped, RETURNING produces
+  -- no row, v_earning_id stays NULL, and we raise
+  -- 'earning_already_withdrawn' below. No money moves into a row
+  -- that won't pay out.
+  insert into public.creator_earnings (
+    creator_id, fan_edit_id, partner_id, title_id,
+    views_at_calculation, earnings_cents,
+    calculation_date, campaign_id, claimed
+  ) values (
+    p_creator_id, v_md_fan_edit_id, p_partner_id, p_title_id,
+    v_views, v_billed_cents,
+    current_date, v_md_campaign_id, not coalesce(v_is_stub, false)
+  )
+  on conflict (creator_id, fan_edit_id, calculation_date,
+               campaign_id)
+  do update set
+    earnings_cents = public.creator_earnings.earnings_cents
+                     + excluded.earnings_cents,
+    views_at_calculation = excluded.views_at_calculation
+  where public.creator_earnings.withdrawn_at is null
+  returning id into v_earning_id;
+
+  if v_earning_id is null then
+    raise exception 'earning_already_withdrawn';
+  end if;
+
+  -- Per-delta ledger debit. NOT aggregated — the ledger records one
+  -- debit per delta even when earnings rows aggregate, so per-delta
+  -- auditability is preserved.
+  insert into public.campaign_ledger (
+    campaign_id, entry_type, amount_cents,
+    creator_earning_id, campaign_funding_id, note
+  ) values (
+    v_md_campaign_id, 'payout', -v_billed_cents,
+    v_earning_id, null, null
+  );
+
+  -- Flip the metering delta to billed and stamp its links.
+  update public.campaign_metering_deltas
+    set status = 'billed',
+        creator_earning_id = v_earning_id,
+        prorata_run_id = p_prorata_run_id,
+        prorata_factor = p_prorata_factor,
+        updated_at = now()
+    where id = p_metering_delta_id;
+
+  return v_earning_id;
+end;
+$$;
+
+revoke execute on function public.bill_settled_delta(
+  uuid, uuid, numeric, integer, uuid, uuid, uuid
+) from public, anon, authenticated;
+
+grant execute on function public.bill_settled_delta(
+  uuid, uuid, numeric, integer, uuid, uuid, uuid
+) to service_role;


### PR DESCRIPTION
## Commit (i) of the money-rail remediation

Fixes the floor()-prorata residue that made strict-zero completion unreachable (campaign e8150462 froze at 1¢ with 523 settled deltas).

### Changes
- **`pass2BillSettled` → two-pass.** Pass 1 computes the authoritative per-delta amount via **integer largest-remainder (Hamilton)** apportionment on the prorata branch so the billed sum drains the pool to **exactly 0**. Full-CPM branch is **unchanged** (bills integer `full_cpm`). Pass 2 writes in FIFO order. An invariant guard (`Σ final === pool`) bails the run safely if violated (writes nothing).
- **`bill_settled_delta` RPC.** New `p_billed_cents` parameter is the money source; the internal `floor(full_cpm × factor)` recompute is removed. `p_prorata_factor` is retained **only** to stamp the delta (audit). Signature change ⇒ **DROP then CREATE**. All other behavior preserved verbatim: day-key `ON CONFLICT` accumulation, idempotent replay, withdrawn-row guard, every RAISE path, service-role lockdown.
- **Void decoupled** from the mid-loop `poolExhausted` JS tracker; now gated on the authoritative ledger SUM (`poolAfter === 0`) — the same condition that fires completion — so completion and void always fire together.

### Safety
- Integer arithmetic throughout (no JS-double factor touches money). Verified magnitude: worst-case per-row product `pool × full_cpm = 3.18×10⁹` ≪ `MAX_SAFE_INTEGER` (9.0×10¹⁵).
- Deterministic leftover-cent tiebreak: `remainder DESC, appeared_at ASC, id ASC` (reproducible under retry).
- `next build` clean. Edge Function typechecked at deploy.

Commit (ii) — cron head-of-line fairness — is **separate** and follows after this ships and validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)