### PR TITLE
admin: manual title creation (film/series) — POST /api/admin/titles + CreateTitleModal

### DIFF
--- a/src/app/admin/CreateTitleButton.tsx
+++ b/src/app/admin/CreateTitleButton.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useState } from "react";
+import CreateTitleModal from "./CreateTitleModal";
+
+export default function CreateTitleButton() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-md border border-moonbeem-pink/40 px-4 py-2 text-body-sm font-semibold text-moonbeem-pink hover:border-moonbeem-pink hover:bg-moonbeem-pink/10"
+      >
+        + Create title
+      </button>
+      {open && <CreateTitleModal onClose={() => setOpen(false)} />}
+    </>
+  );
+}

--- a/src/app/admin/CreateTitleModal.tsx
+++ b/src/app/admin/CreateTitleModal.tsx
@@ -1,0 +1,454 @@
+"use client";
+
+// Manually create a non-TMDB title (film/series) and attach it to a
+// partner in one step. Patterned on AttachTitleModal — same partner
+// picker (existing / inline-create) and the same is_active/is_public/
+// is_featured controls — but instead of searching the catalog it takes
+// title metadata and POSTs to /api/admin/titles (which INSERTs the row).
+// media_type is restricted to movie/tv here, matching the endpoint's
+// tier-3 guard.
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import PartnerLogoUploader from "@/components/admin/PartnerLogoUploader";
+import { fetchJson, FetchJsonError, RateLimitedError } from "@/lib/fetch-json";
+
+type Partner = {
+  id: string;
+  slug: string;
+  name: string;
+  logo_url: string | null;
+};
+
+type Mode = "pick-existing" | "create-new";
+type Props = { onClose: () => void };
+
+// "Last Tango in Park City" + 2026 → "last-tango-in-park-city-2026".
+// Mirrors baseTitleSlug() in /api/admin/titles so the pre-fill matches
+// what the server would generate.
+function suggestTitleSlug(title: string, year: string): string {
+  const base = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+  const y = year.trim();
+  return base && /^\d{4}$/.test(y) ? `${base}-${y}` : base;
+}
+
+// "Topic Studios" → "topic-studios" (partner slug suggester, same as attach).
+function suggestPartnerSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export default function CreateTitleModal({ onClose }: Props) {
+  const router = useRouter();
+
+  // Title metadata
+  const [title, setTitle] = useState("");
+  const [mediaType, setMediaType] = useState<"movie" | "tv">("movie");
+  const [year, setYear] = useState("");
+  const [posterUrl, setPosterUrl] = useState("");
+  const [synopsis, setSynopsis] = useState("");
+  const [slug, setSlug] = useState("");
+  const [slugTouched, setSlugTouched] = useState(false);
+
+  // Partner state (same shape as AttachTitleModal)
+  const [partners, setPartners] = useState<Partner[] | null>(null);
+  const [partnersErr, setPartnersErr] = useState<string | null>(null);
+  const [mode, setMode] = useState<Mode>("pick-existing");
+  const [partnerId, setPartnerId] = useState<string>("");
+  const [newName, setNewName] = useState("");
+  const [newSlug, setNewSlug] = useState("");
+  const [newSlugTouched, setNewSlugTouched] = useState(false);
+  const [newLogoKey, setNewLogoKey] = useState<string | null>(null);
+  const [newLogoPreview, setNewLogoPreview] = useState<string | null>(null);
+
+  // Flags — manual titles are created to launch, so public/active default on.
+  const [isActive, setIsActive] = useState(true);
+  const [isPublic, setIsPublic] = useState(true);
+  const [isFeatured, setIsFeatured] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitErr, setSubmitErr] = useState<string | null>(null);
+
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    titleInputRef.current?.focus();
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/admin/partners")
+      .then((r) => r.json())
+      .then((j) => {
+        if (!alive) return;
+        if (Array.isArray(j.partners)) setPartners(j.partners);
+        else setPartnersErr(j.error ?? "load_failed");
+      })
+      .catch((e) => alive && setPartnersErr(String(e)));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // Auto-suggest the title slug until the admin edits it.
+  useEffect(() => {
+    if (!slugTouched) setSlug(suggestTitleSlug(title, year));
+  }, [title, year, slugTouched]);
+
+  // Auto-suggest the new-partner slug until the admin edits it.
+  useEffect(() => {
+    if (!newSlugTouched) setNewSlug(suggestPartnerSlug(newName));
+  }, [newName, newSlugTouched]);
+
+  function partnerReady(): boolean {
+    if (mode === "pick-existing") return !!partnerId;
+    return newName.trim().length > 0 && SLUG_RE.test(newSlug);
+  }
+  function ready(): boolean {
+    if (!title.trim()) return false;
+    if (!SLUG_RE.test(slug)) return false;
+    if (year.trim() && !/^\d{4}$/.test(year.trim())) return false;
+    return partnerReady();
+  }
+
+  async function submit() {
+    if (submitting || !ready()) return;
+    setSubmitting(true);
+    setSubmitErr(null);
+
+    const payload: Record<string, unknown> = {
+      title: title.trim(),
+      media_type: mediaType,
+      is_active: isActive,
+      is_public: isPublic,
+      is_featured: isFeatured,
+    };
+    if (year.trim()) payload.year = Number(year.trim());
+    if (posterUrl.trim()) payload.poster_url = posterUrl.trim();
+    if (synopsis.trim()) payload.synopsis = synopsis.trim();
+    // Only send an explicit slug when the admin edited it; otherwise let
+    // the server auto-generate + auto-disambiguate (-2, -3, …).
+    if (slugTouched && slug.trim()) payload.slug = slug.trim();
+    if (mode === "pick-existing") {
+      payload.partner_id = partnerId;
+    } else {
+      const np: Record<string, unknown> = {
+        name: newName.trim(),
+        slug: newSlug.trim(),
+      };
+      if (newLogoKey) np.logo_key = newLogoKey;
+      payload.new_partner = np;
+    }
+
+    try {
+      const j = await fetchJson<{ ok?: boolean; title?: { slug: string } }>(
+        "/api/admin/titles",
+        { method: "POST", body: payload },
+      );
+      if (!j.ok || !j.title) {
+        setSubmitErr("Create didn't complete. Try again.");
+        return;
+      }
+      router.push(`/admin/titles/${j.title.slug}`);
+    } catch (e) {
+      setSubmitErr(
+        e instanceof RateLimitedError || e instanceof FetchJsonError
+          ? e.userMessage
+          : e instanceof Error
+            ? e.message
+            : String(e),
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/70 backdrop-blur-sm p-4 pt-12"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-full max-w-2xl rounded-2xl border border-white/10 bg-moonbeem-black p-6 shadow-2xl">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="m-0 font-wordmark text-heading-md text-moonbeem-pink">
+              Create a title
+            </h2>
+            <p className="mt-1 text-caption text-moonbeem-ink-subtle">
+              For a film or series that isn&apos;t in the TMDB catalog. Public
+              and Active by default so it&apos;s campaign-ready.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-white/10 px-2 py-1 text-caption text-moonbeem-ink-muted hover:border-moonbeem-pink hover:text-moonbeem-pink"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* STEP 1 — title metadata */}
+        <section className="mt-6 flex flex-col gap-3">
+          <label className="flex flex-col gap-1 text-body-sm font-medium text-moonbeem-ink">
+            Title
+            <input
+              ref={titleInputRef}
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Last Tango in Park City"
+              className="rounded-md border border-white/10 bg-black/30 px-3 py-2 text-body-sm text-moonbeem-ink placeholder:text-moonbeem-ink-subtle focus:border-moonbeem-pink focus:outline-none"
+            />
+          </label>
+
+          <div className="flex flex-wrap gap-3">
+            <label className="flex flex-col gap-1 text-caption text-moonbeem-ink-subtle">
+              Type
+              <select
+                value={mediaType}
+                onChange={(e) => setMediaType(e.target.value as "movie" | "tv")}
+                className="rounded-md border border-white/10 bg-black/30 px-3 py-2 text-body-sm text-moonbeem-ink focus:border-moonbeem-pink focus:outline-none"
+              >
+                <option value="movie">Film (movie)</option>
+                <option value="tv">Series (tv)</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-1 text-caption text-moonbeem-ink-subtle">
+              Year
+              <input
+                type="text"
+                inputMode="numeric"
+                value={year}
+                onChange={(e) => setYear(e.target.value)}
+                placeholder="2026"
+                className="w-24 rounded-md border border-white/10 bg-black/30 px-3 py-2 text-body-sm text-moonbeem-ink placeholder:text-moonbeem-ink-subtle focus:border-moonbeem-pink focus:outline-none"
+              />
+            </label>
+          </div>
+
+          <label className="flex flex-col gap-1 text-caption text-moonbeem-ink-subtle">
+            Slug
+            <input
+              type="text"
+              value={slug}
+              onChange={(e) => {
+                setSlug(e.target.value);
+                setSlugTouched(true);
+              }}
+              placeholder="last-tango-in-park-city-2026"
+              className="rounded-md border border-white/10 bg-black/30 px-3 py-2 font-mono text-body-sm text-moonbeem-ink focus:border-moonbeem-pink focus:outline-none"
+            />
+            <span className="text-caption text-moonbeem-ink-subtle">
+              URL becomes /t/{slug || "<slug>"}. Auto-generated; edit to override
+              (a collision returns 409). Lower-case, hyphens only.
+            </span>
+          </label>
+
+          <label className="flex flex-col gap-1 text-caption text-moonbeem-ink-subtle">
+            Poster URL (optional)
+            <input
+              type="text"
+              value={posterUrl}
+              onChange={(e) => setPosterUrl(e.target.value)}
+              placeholder="https://…/poster.jpg"
+              className="rounded-md border border-white/10 bg-black/30 px-3 py-2 text-body-sm text-moonbeem-ink placeholder:text-moonbeem-ink-subtle focus:border-moonbeem-pink focus:outline-none"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-caption text-moonbeem-ink-subtle">
+            Synopsis (optional)
+            <textarea
+              value={synopsis}
+              onChange={(e) => setSynopsis(e.target.value)}
+              rows={3}
+              placeholder="One or two sentences…"
+              className="rounded-md border border-white/10 bg-black/30 px-3 py-2 text-body-sm text-moonbeem-ink placeholder:text-moonbeem-ink-subtle focus:border-moonbeem-pink focus:outline-none"
+            />
+          </label>
+        </section>
+
+        {/* STEP 2 — pick / create partner (same controls as AttachTitleModal) */}
+        <section className="mt-6 flex flex-col gap-3">
+          <label className="text-body-sm font-medium text-moonbeem-ink">
+            Partner
+          </label>
+          <div className="flex items-center gap-4 text-caption">
+            <label className="flex items-center gap-1.5">
+              <input
+                type="radio"
+                checked={mode === "pick-existing"}
+                onChange={() => setMode("pick-existing")}
+                className="accent-moonbeem-pink"
+              />
+              <span>Existing</span>
+            </label>
+            <label className="flex items-center gap-1.5">
+              <input
+                type="radio"
+                checked={mode === "create-new"}
+                onChange={() => setMode("create-new")}
+                className="accent-moonbeem-pink"
+              />
+              <span>Create new</span>
+            </label>
+          </div>
+
+          {mode === "pick-existing" && (
+            <>
+              {partnersErr && (
+                <p className="text-caption text-moonbeem-magenta">{partnersErr}</p>
+              )}
+              <select
+                value={partnerId}
+                onChange={(e) => setPartnerId(e.target.value)}
+                className="rounded-md border border-white/10 bg-black/30 px-3 py-2 text-body-sm text-moonbeem-ink focus:border-moonbeem-pink focus:outline-none"
+              >
+                <option value="">— select a partner —</option>
+                {(partners ?? []).map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name} ({p.slug})
+                  </option>
+                ))}
+              </select>
+            </>
+          )}
+
+          {mode === "create-new" && (
+            <div className="flex flex-col gap-3 rounded-lg border border-white/5 bg-white/[0.02] p-4">
+              <label className="flex flex-col gap-1 text-caption text-moonbeem-ink-subtle">
+                Name
+                <input
+                  type="text"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="Roadside Attractions"
+                  className="rounded-md border border-white/10 bg-black/30 px-3 py-2 text-body-sm text-moonbeem-ink focus:border-moonbeem-pink focus:outline-none"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-caption text-moonbeem-ink-subtle">
+                Slug
+                <input
+                  type="text"
+                  value={newSlug}
+                  onChange={(e) => {
+                    setNewSlug(e.target.value);
+                    setNewSlugTouched(true);
+                  }}
+                  placeholder="roadside-attractions"
+                  className="rounded-md border border-white/10 bg-black/30 px-3 py-2 font-mono text-body-sm text-moonbeem-ink focus:border-moonbeem-pink focus:outline-none"
+                />
+                <span className="text-caption text-moonbeem-ink-subtle">
+                  Lower-case, hyphens only. URL becomes /p/{newSlug || "<slug>"}.
+                </span>
+              </label>
+              <div className="flex flex-col gap-2">
+                <span className="text-caption text-moonbeem-ink-subtle">
+                  Logo (optional)
+                </span>
+                <PartnerLogoUploader
+                  partnerSlug={newSlug}
+                  initialUrl={newLogoPreview}
+                  onUploaded={({ key, previewUrl }) => {
+                    setNewLogoKey(key);
+                    setNewLogoPreview(previewUrl);
+                  }}
+                  onCleared={() => {
+                    setNewLogoKey(null);
+                    setNewLogoPreview(null);
+                  }}
+                />
+              </div>
+            </div>
+          )}
+        </section>
+
+        {/* STEP 3 — initial flags (same controls as AttachTitleModal) */}
+        <section className="mt-6 flex flex-col gap-3">
+          <label className="text-body-sm font-medium text-moonbeem-ink">
+            Initial state
+          </label>
+          <div className="flex flex-wrap items-center gap-6 text-body-sm">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={isActive}
+                onChange={(e) => {
+                  setIsActive(e.target.checked);
+                  if (!e.target.checked) setIsPublic(false);
+                }}
+                className="accent-moonbeem-pink"
+              />
+              <span className="text-moonbeem-ink">Active</span>
+              <span className="text-caption text-moonbeem-ink-subtle">
+                (CPM payouts, partner dashboard, view tracking)
+              </span>
+            </label>
+            <label className={`flex items-center gap-2 ${isActive ? "" : "opacity-50"}`}>
+              <input
+                type="checkbox"
+                checked={isPublic}
+                disabled={!isActive}
+                onChange={(e) => setIsPublic(e.target.checked)}
+                className="accent-moonbeem-pink"
+              />
+              <span className="text-moonbeem-ink">Public</span>
+              <span className="text-caption text-moonbeem-ink-subtle">
+                (anonymous /t/{slug || "<slug>"} renders)
+              </span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={isFeatured}
+                onChange={(e) => setIsFeatured(e.target.checked)}
+                className="accent-moonbeem-pink"
+              />
+              <span className="text-moonbeem-ink">Add to Featured carousel</span>
+              <span className="text-caption text-moonbeem-ink-subtle">
+                (appears on homepage Featured row)
+              </span>
+            </label>
+          </div>
+        </section>
+
+        {/* Submit */}
+        <div className="mt-8 flex items-center justify-end gap-3">
+          {submitErr && (
+            <p className="mr-auto text-caption text-moonbeem-magenta">{submitErr}</p>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-white/10 px-4 py-2 text-body-sm text-moonbeem-ink-muted hover:border-moonbeem-pink hover:text-moonbeem-pink"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={!ready() || submitting}
+            className="rounded-md bg-moonbeem-pink px-5 py-2 text-body-sm font-semibold text-moonbeem-navy hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitting ? "Creating…" : "Create title"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/admin-action-runs";
 import AdminQuickActions from "./AdminQuickActions";
 import AttachTitleButton from "./AttachTitleButton";
+import CreateTitleButton from "./CreateTitleButton";
 import PartnerRow from "./PartnerRow";
 import TitleRowControls from "./TitleRowControls";
 
@@ -536,6 +537,7 @@ export default async function AdminLanding() {
               >
                 Curate featured →
               </Link>
+              <CreateTitleButton />
               <AttachTitleButton />
             </div>
           </div>

--- a/src/app/api/admin/titles/route.ts
+++ b/src/app/api/admin/titles/route.ts
@@ -1,0 +1,320 @@
+// POST /api/admin/titles — manually CREATE a non-TMDB title (film/series).
+//
+// The catalog-sync Edge Function is the only OTHER path that inserts a
+// titles row; it covers the ~1.4M TMDB catalog. This endpoint is the
+// manual create-path for titles that aren't in TMDB (a non-TMDB film,
+// or a series), so a partner can run a campaign on them.
+//
+// Body: {
+//   title: string,                       // required
+//   media_type: 'movie' | 'tv',          // required — REJECTS anything
+//                                         //   else (the tier-3 guard:
+//                                         //   non-film can't be created
+//                                         //   until its rendering exists)
+//   year?: number,                       // optional
+//   poster_url?: string,                 // optional (external URL, v1)
+//   synopsis?: string,                   // optional
+//   director?: string,                   // optional
+//   runtime_min?: number,                // optional
+//   slug?: string,                       // optional manual override;
+//                                         //   else auto-generated from
+//                                         //   title (+ year)
+//   partner_id?: string,                 // either this …
+//   new_partner?: { name, slug, logo_url?, logo_key? }, // … or this
+//   is_active?: boolean,                 // default true
+//   is_public?: boolean,                 // default true (created to launch)
+//   is_featured?: boolean,               // default false
+// }
+//
+// Mirrors POST /api/admin/titles/attach for auth + partner resolution,
+// but INSERTs a titles row instead of UPDATEing an existing one. Sets
+// created_by = the authenticated admin and tmdb_id = null (these are
+// non-TMDB rows; the partial unique (tmdb_id, media_type) index does not
+// touch null-tmdb rows). Super-admin only. No schema change.
+
+import { NextResponse, type NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { requireSuperAdmin } from "@/lib/dal";
+import { enforce } from "@/lib/ratelimit";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { buildPublicUrl } from "@/lib/r2/upload";
+import { nextFeaturedOrder } from "@/lib/featured-order";
+import { nextMarqueeOrder } from "@/lib/marquee-order";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const ALLOWED_MEDIA_TYPES = ["movie", "tv"] as const;
+
+type NewPartner = {
+  name?: string;
+  slug?: string;
+  logo_url?: string | null;
+  logo_key?: string | null;
+};
+type Body = {
+  title?: string;
+  media_type?: string;
+  year?: number | null;
+  poster_url?: string | null;
+  synopsis?: string | null;
+  director?: string | null;
+  runtime_min?: number | null;
+  slug?: string;
+  partner_id?: string | null;
+  new_partner?: NewPartner;
+  is_active?: boolean;
+  is_public?: boolean;
+  is_featured?: boolean;
+};
+
+// "Last Tango in Park City" + 2026 → "last-tango-in-park-city-2026".
+// Same kebab discipline as the partner slug suggester.
+function baseTitleSlug(title: string, year: number | null): string {
+  const base = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+  return year ? `${base}-${year}` : base;
+}
+
+// Find a free slug by appending -2, -3, … against the whole titles
+// table (idx_titles_slug makes the exact-match lookup cheap). The
+// manual scheme is structurally distinct from the TMDB stub scheme
+// (tmdb-{m|t}-{id}), so collisions are rare, but we check regardless.
+async function resolveUniqueSlug(
+  supabase: SupabaseClient,
+  base: string,
+): Promise<string> {
+  for (let i = 1; i <= 50; i++) {
+    const candidate = i === 1 ? base : `${base}-${i}`;
+    const { data, error } = await supabase
+      .from("titles")
+      .select("id")
+      .eq("slug", candidate)
+      .maybeSingle();
+    if (error) throw new Error(`slug check: ${error.message}`);
+    if (!data) return candidate;
+  }
+  throw new Error("slug_unresolvable");
+}
+
+export async function POST(request: NextRequest) {
+  const session = await requireSuperAdmin();
+  const limit = await enforce("admin", session.userId, "admin/titles/create");
+  if (!limit.ok) return limit.response;
+
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  // --- title ---
+  const title = (body.title ?? "").trim();
+  if (!title) {
+    return NextResponse.json({ error: "title_required" }, { status: 400 });
+  }
+
+  // --- media_type (the tier-3 guard) ---
+  const mediaType = body.media_type;
+  if (
+    typeof mediaType !== "string" ||
+    !(ALLOWED_MEDIA_TYPES as readonly string[]).includes(mediaType)
+  ) {
+    return NextResponse.json(
+      { error: "invalid_media_type", allowed: ALLOWED_MEDIA_TYPES },
+      { status: 400 },
+    );
+  }
+
+  // --- optional scalars ---
+  let year: number | null = null;
+  if (body.year !== undefined && body.year !== null) {
+    if (
+      typeof body.year !== "number" ||
+      !Number.isInteger(body.year) ||
+      body.year < 1870 ||
+      body.year > 2100
+    ) {
+      return NextResponse.json({ error: "invalid_year" }, { status: 400 });
+    }
+    year = body.year;
+  }
+  let runtimeMin: number | null = null;
+  if (body.runtime_min !== undefined && body.runtime_min !== null) {
+    if (
+      typeof body.runtime_min !== "number" ||
+      !Number.isInteger(body.runtime_min) ||
+      body.runtime_min < 0
+    ) {
+      return NextResponse.json({ error: "invalid_runtime" }, { status: 400 });
+    }
+    runtimeMin = body.runtime_min;
+  }
+  const posterUrl = body.poster_url?.trim() || null;
+  const synopsis = body.synopsis?.trim() || null;
+  const director = body.director?.trim() || null;
+
+  // --- partner presence ---
+  if (
+    body.partner_id !== undefined &&
+    body.partner_id !== null &&
+    !UUID_RE.test(body.partner_id)
+  ) {
+    return NextResponse.json({ error: "invalid_partner_id" }, { status: 400 });
+  }
+  if (!body.partner_id && !body.new_partner) {
+    return NextResponse.json(
+      { error: "partner_id_or_new_partner_required" },
+      { status: 400 },
+    );
+  }
+
+  // --- flags (manual titles are created to launch: public/active default true) ---
+  const isActive = body.is_active ?? true;
+  const isPublic = body.is_public ?? true;
+  const isFeatured = body.is_featured ?? false;
+  if (
+    typeof isActive !== "boolean" ||
+    typeof isPublic !== "boolean" ||
+    typeof isFeatured !== "boolean"
+  ) {
+    return NextResponse.json({ error: "flag_not_boolean" }, { status: 400 });
+  }
+  if (isPublic && !isActive) {
+    return NextResponse.json(
+      { error: "public_requires_active" },
+      { status: 400 },
+    );
+  }
+
+  const supabase = createServiceRoleClient();
+
+  // --- partner resolution (same logic as /api/admin/titles/attach) ---
+  let partnerId: string;
+  let partnerRow: { id: string; slug: string; name: string; logo_url: string | null };
+
+  if (body.new_partner) {
+    const name = (body.new_partner.name ?? "").trim();
+    const slug = (body.new_partner.slug ?? "").trim().toLowerCase();
+    const logoKey = body.new_partner.logo_key?.trim() || null;
+    const logoUrl = logoKey
+      ? buildPublicUrl(logoKey)
+      : body.new_partner.logo_url?.trim() || null;
+    if (!name) {
+      return NextResponse.json({ error: "partner_name_required" }, { status: 400 });
+    }
+    if (!slug || !SLUG_RE.test(slug)) {
+      return NextResponse.json({ error: "invalid_partner_slug" }, { status: 400 });
+    }
+    const marqueeOrder = await nextMarqueeOrder(supabase);
+    const { data, error } = await supabase
+      .from("partners")
+      .insert({
+        name,
+        slug,
+        logo_url: logoUrl,
+        is_marquee_visible: true,
+        marquee_order: marqueeOrder,
+      })
+      .select("id, slug, name, logo_url")
+      .single();
+    if (error) {
+      if (error.code === "23505") {
+        return NextResponse.json({ error: "partner_slug_taken" }, { status: 409 });
+      }
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    partnerRow = data as typeof partnerRow;
+    partnerId = partnerRow.id;
+    if (logoUrl) revalidatePath("/");
+  } else {
+    const { data, error } = await supabase
+      .from("partners")
+      .select("id, slug, name, logo_url")
+      .eq("id", body.partner_id as string)
+      .maybeSingle();
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    if (!data) {
+      return NextResponse.json({ error: "partner_not_found" }, { status: 404 });
+    }
+    partnerRow = data as typeof partnerRow;
+    partnerId = partnerRow.id;
+  }
+
+  // --- slug: explicit override (validate + 409 on conflict) OR auto-generate (auto-disambiguate) ---
+  let slug: string;
+  if (body.slug !== undefined && body.slug.trim() !== "") {
+    const override = body.slug.trim().toLowerCase();
+    if (!SLUG_RE.test(override)) {
+      return NextResponse.json({ error: "invalid_slug" }, { status: 400 });
+    }
+    const { data: clash, error: clashErr } = await supabase
+      .from("titles")
+      .select("id")
+      .eq("slug", override)
+      .maybeSingle();
+    if (clashErr) {
+      return NextResponse.json({ error: clashErr.message }, { status: 500 });
+    }
+    if (clash) {
+      return NextResponse.json({ error: "slug_taken" }, { status: 409 });
+    }
+    slug = override;
+  } else {
+    try {
+      slug = await resolveUniqueSlug(supabase, baseTitleSlug(title, year));
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      const status = msg === "slug_unresolvable" ? 409 : 500;
+      return NextResponse.json({ error: msg }, { status });
+    }
+  }
+
+  // --- insert the title ---
+  const titleInsert: Record<string, unknown> = {
+    slug,
+    title,
+    media_type: mediaType,
+    year,
+    poster_url: posterUrl,
+    synopsis,
+    director,
+    runtime_min: runtimeMin,
+    partner_id: partnerId,
+    is_active: isActive,
+    is_public: isPublic,
+    is_featured: isFeatured,
+    created_by: session.userId,
+    tmdb_id: null,
+  };
+  if (isFeatured) {
+    titleInsert.featured_order = await nextFeaturedOrder(supabase);
+  }
+
+  const { data: titleRow, error: titleErr } = await supabase
+    .from("titles")
+    .insert(titleInsert)
+    .select(
+      "id, slug, title, year, media_type, partner_id, is_active, is_public, is_featured",
+    )
+    .single();
+
+  if (titleErr) {
+    // 23505 = unique violation (slug raced between our check and insert).
+    if (titleErr.code === "23505") {
+      return NextResponse.json({ error: "slug_taken" }, { status: 409 });
+    }
+    return NextResponse.json({ error: titleErr.message }, { status: 500 });
+  }
+
+  if (isPublic || isFeatured) revalidatePath("/");
+
+  return NextResponse.json({ ok: true, partner: partnerRow, title: titleRow });
+}

--- a/src/components/FanEditCard.tsx
+++ b/src/components/FanEditCard.tsx
@@ -80,6 +80,10 @@ export default function FanEditCard({
     }
   }
 
+  // Both can be null (a deleted-from-platform fan_edit on a poster-less
+  // title), so guard before rendering — <Image src={null}> breaks the rail.
+  const thumbSrc = fanEdit.thumbnail_url ?? fanEdit.title_poster_url;
+
   return (
     // Outer wrapper enforces aspect-ratio independently of the
     // motion.button's layoutId measurement — same split pattern
@@ -92,19 +96,26 @@ export default function FanEditCard({
       onClick={openModal}
       className="group absolute inset-0 block cursor-pointer overflow-hidden rounded-xl bg-moonbeem-navy/40 text-left transition-[transform,box-shadow] duration-300 ease-[cubic-bezier(0.25,1,0.5,1)] hover:scale-[1.03] hover:shadow-[0_20px_40px_rgba(245,197,225,0.3)] focus:outline-none focus-visible:ring-2 focus-visible:ring-moonbeem-pink"
     >
-      <Image
-        src={fanEdit.thumbnail_url ?? fanEdit.title_poster_url}
-        alt={
-          fanEdit.thumbnail_url
-            ? `${fanEdit.title_name} fan edit by ${displayHandle ?? "@anon"}`
-            : `${fanEdit.title_name} poster`
-        }
-        fill
-        sizes="(max-width: 768px) 75vw, 280px"
-        draggable={false}
-        className="select-none object-cover"
-        unoptimized={!!fanEdit.thumbnail_url}
-      />
+      {thumbSrc ? (
+        <Image
+          src={thumbSrc}
+          alt={
+            fanEdit.thumbnail_url
+              ? `${fanEdit.title_name} fan edit by ${displayHandle ?? "@anon"}`
+              : `${fanEdit.title_name} poster`
+          }
+          fill
+          sizes="(max-width: 768px) 75vw, 280px"
+          draggable={false}
+          className="select-none object-cover"
+          unoptimized={!!fanEdit.thumbnail_url}
+        />
+      ) : (
+        <div
+          aria-hidden
+          className="absolute inset-0 bg-gradient-to-br from-moonbeem-navy to-black"
+        />
+      )}
 
       <div className="absolute left-3 top-3 flex h-7 w-7 items-center justify-center rounded-full bg-black/60 text-moonbeem-ink backdrop-blur-sm">
         <PlatformIcon platform={fanEdit.platform} className="h-4 w-4" />


### PR DESCRIPTION
## Tier-2 manual title creation

Adds the missing manual title-INSERT path so non-TMDB films and series can be onboarded and run campaigns (the catalog-sync Edge Function was the only inserter; the attach flow is UPDATE-only).

- **`POST /api/admin/titles`** — super-admin endpoint that INSERTs a titles row. `media_type` restricted to `{movie,tv}` (400 otherwise — the tier-3 guard). Reuses the attach route's exact partner resolution (existing `partner_id` or inline `new_partner`). Auto-unique slug from title+year (kebab + `-2/-3`) with an editable, kebab-validated override (409 on conflict). Sets `is_public/is_active=true`, `created_by = admin user_id`, `tmdb_id=null`.
- **`CreateTitleModal` + `CreateTitleButton`** — sibling to the attach modal (kept `AttachTitleModal` byte-identical); same partner picker + inline-create + flag controls, plus a title-metadata form.
- **FanEditCard** — guard `<Image src>` when both `thumbnail_url` and `title_poster_url` are null (latent null-src defect; poster-less manual titles would trip it).

**No migration. `media_type` stays `{movie,tv}`. No money-rail/cron/media_type-filter touched.** `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)