### PR TITLE
homepage: Series rail (media_type='tv') + neutralize search film copy

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import {
   getAllFilms,
   getFeaturedTitles,
   getRecentFanEdits,
+  getSeriesTitles,
   getTitlesWithActiveCampaigns,
   getTrendingFanEdits,
 } from "@/lib/queries/titles";
@@ -26,6 +27,7 @@ export default async function Home() {
     allFilms,
     trending,
     activeCampaignTitles,
+    series,
   ] = await Promise.all([
     getHomepageSectionOrder(),
     getFeaturedTitles(),
@@ -34,6 +36,7 @@ export default async function Home() {
     getAllFilms(),
     getTrendingFanEdits(12),
     getTitlesWithActiveCampaigns(),
+    getSeriesTitles(),
   ]);
 
   // Renderer-per-slug — keeps the conditional length>0 guard
@@ -78,8 +81,27 @@ export default async function Home() {
   // larger bottom padding (pb-20) there instead of pb-10. This used
   // to be hardcoded to "All Films" pre-slice-D; under arbitrary
   // reorder it's whichever section ends up rendered last.
-  const rendered: Array<{ slug: HomepageSectionSlug; node: React.ReactNode }> =
+  const rendered: Array<{ slug: string; node: React.ReactNode }> =
     order.map((slug) => ({ slug, node: renderers[slug]() }));
+  // Series rail — a fixed shelf rendered immediately after All Films.
+  // NOT a homepage_sections slug: keeping it out of the orderable
+  // taxonomy avoids touching the section CHECK constraint, the admin
+  // reorder route, and a migration. Splices right after the all-films
+  // node (falls back to the end if all-films isn't in the configured
+  // order). Guarded on empty so there's no "Series" header on an
+  // empty shelf (TitleCarousel also no-ops on an empty list).
+  if (series.length > 0) {
+    const seriesEntry = {
+      slug: "series",
+      node: <TitleCarousel title="Series" titles={series} />,
+    };
+    const afterAllFilms = rendered.findIndex((r) => r.slug === "all-films");
+    if (afterAllFilms >= 0) {
+      rendered.splice(afterAllFilms + 1, 0, seriesEntry);
+    } else {
+      rendered.push(seriesEntry);
+    }
+  }
   const visibleIndexes = rendered
     .map((r, i) => (r.node ? i : -1))
     .filter((i) => i >= 0);

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata({
   const { q, person } = await searchParams;
   const personTrimmed = (person ?? "").trim();
   if (personTrimmed) {
-    return { title: `Films with ${personTrimmed} · Moonbeem` };
+    return { title: `Titles with ${personTrimmed} · Moonbeem` };
   }
   const trimmed = (q ?? "").trim();
   return {
@@ -30,11 +30,11 @@ export default async function SearchPage({ searchParams }: PageProps) {
       <div className="flex-1 py-12">
         <div className="mx-auto max-w-7xl px-6">
           <h1 className="font-wordmark text-display-sm md:text-display-md text-moonbeem-pink m-0">
-            Films with {personName}
+            Titles with {personName}
           </h1>
           <p className="mt-2 text-body-sm text-moonbeem-ink-muted">
             {results.length === 0
-              ? `No films found for ${personName}.`
+              ? `No titles found for ${personName}.`
               : `${personName} appears in ${results.length} ${
                   results.length === 1 ? "title" : "titles"
                 }`}
@@ -72,7 +72,7 @@ export default async function SearchPage({ searchParams }: PageProps) {
               Search
             </h1>
             <p className="text-body text-moonbeem-ink-muted">
-              Search for any film in our catalog of 86,000+ titles.
+              Search for any title in our catalog of 86,000+ titles.
             </p>
           </div>
         ) : (
@@ -82,8 +82,8 @@ export default async function SearchPage({ searchParams }: PageProps) {
             </h1>
             <p className="mt-2 text-body-sm text-moonbeem-ink-muted">
               {results.length === 0
-                ? `No films match '${query}'. Try a different search.`
-                : `${results.length} ${results.length === 1 ? "film" : "films"}`}
+                ? `No titles match '${query}'. Try a different search.`
+                : `${results.length} ${results.length === 1 ? "title" : "titles"}`}
             </p>
 
             {results.length > 0 && (

--- a/src/lib/queries/titles.ts
+++ b/src/lib/queries/titles.ts
@@ -220,6 +220,27 @@ export async function getAllFilms(): Promise<Title[]> {
   return data as Title[];
 }
 
+// The TV-series analog of getAllFilms — feeds the homepage "Series"
+// rail. Same is_public + is_active gate and same ordering as the films
+// catalog, but media_type='tv'. Deliberately does NOT filter
+// is_hidden_from_all_films (that flag is film-rail scoped). Uses the
+// service-role client to match getAllFilms (the catalog rail this
+// mirrors). When the title_type column ships (see getAllFilms note),
+// swap the filter to title_type='tv_series'.
+export async function getSeriesTitles(): Promise<Title[]> {
+  const supabase = createServiceRoleClient();
+  const { data, error } = await supabase
+    .from("titles")
+    .select("*")
+    .eq("is_public", true)
+    .eq("is_active", true)
+    .eq("media_type", "tv")
+    .order("allfilms_pin_order", { ascending: true, nullsFirst: false })
+    .order("created_at", { ascending: false });
+  if (error || !data) return [];
+  return data as Title[];
+}
+
 export type TitleOffer = {
   id: string;
   title_id: string;


### PR DESCRIPTION
## Series rail + de-film search copy

- **`getSeriesTitles`** (`titles.ts`) — TV analog of `getAllFilms`: same `is_public`+`is_active` gate and ordering, `media_type='tv'`, no `is_hidden_from_all_films` filter.
- **Homepage** (`page.tsx`) — renders a fixed **"Series"** rail spliced immediately after the All Films node (not a curatable `homepage_sections` slug — avoids the section CHECK/admin-reorder/migration). Guarded on empty.
- **Search** (`search/page.tsx`) — 6 film-only strings neutralized to "title(s)".

`getAllFilms` and its callers untouched. **No migration.** Verified on prod with a throwaway `media_type='tv'` row: appears in getSeriesTitles' query, absent from getAllFilms' query, renders in the Series rail (and not All Films), search shows neutral copy; row torn down (prod holds zero live TV titles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)