### PR TITLE
Watch tab v1: free Instagram episode playback (title_episodes)

### DIFF
--- a/src/app/t/[slug]/page.tsx
+++ b/src/app/t/[slug]/page.tsx
@@ -8,10 +8,12 @@ import {
   getActiveOffersForTitle,
   getActiveStillsForTitle,
   getTitleBySlug,
+  getTitleEpisodes,
   isTitleInActiveCampaign,
   type TitleOffer,
 } from "@/lib/queries/titles";
 import TitleTabs from "@/components/TitleTabs";
+import EpisodeList from "@/components/EpisodeList";
 import FanEditsTab from "@/components/FanEditsTab";
 import VideosTab from "@/components/VideosTab";
 import StillsTab from "@/components/StillsTab";
@@ -114,13 +116,14 @@ export default async function TitlePage({ params }: PageProps) {
     partner_id: title.partner_id,
   });
   if (!visible) notFound();
-  const [offers, fanEdits, clips, stills, hasActiveCampaign] =
+  const [offers, fanEdits, clips, stills, hasActiveCampaign, episodes] =
     await Promise.all([
       getActiveOffersForTitle(title.id),
       getActiveFanEditsForTitle(title.id),
       getActiveClipsForTitle(title.id),
       getActiveStillsForTitle(title.id),
       isTitleInActiveCampaign(title.id),
+      getTitleEpisodes(title.id),
     ]);
 
   const supabase = await createClient();
@@ -254,6 +257,9 @@ export default async function TitlePage({ params }: PageProps) {
 
           <TitleTabs
             aboutContent={aboutContent}
+            watchContent={
+              episodes.length > 0 ? <EpisodeList episodes={episodes} /> : undefined
+            }
             fanEditsContent={
               <>
                 {/* Block 3 entry point: signed-in viewers see a link

--- a/src/components/EpisodeList.tsx
+++ b/src/components/EpisodeList.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import type { TitleEpisode } from "@/lib/queries/titles";
+import EpisodeModal from "./EpisodeModal";
+
+// Watch-tab content: an ordered VERTICAL list of episodes (one row each),
+// not a clip grid. Clicking a row opens the standalone EpisodeModal.
+// Cover thumbnail falls back to a numbered gradient tile when
+// cover_image_url is null — no broken image, no Instagram call.
+export default function EpisodeList({
+  episodes,
+}: {
+  episodes: TitleEpisode[];
+}) {
+  const [openEpisode, setOpenEpisode] = useState<TitleEpisode | null>(null);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {episodes.map((ep) => {
+        const label = ep.label ?? `Episode ${ep.episode_number}`;
+        return (
+          <button
+            key={ep.id}
+            type="button"
+            onClick={() => setOpenEpisode(ep)}
+            className="group flex items-center gap-4 rounded-xl border border-white/10 bg-white/[0.02] p-3 text-left transition-colors hover:border-moonbeem-pink/40 hover:bg-moonbeem-pink/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-moonbeem-pink"
+          >
+            <div className="relative h-[68px] w-[68px] shrink-0 overflow-hidden rounded-lg bg-moonbeem-navy/40">
+              {ep.cover_image_url ? (
+                <Image
+                  src={ep.cover_image_url}
+                  alt={label}
+                  fill
+                  sizes="68px"
+                  className="object-cover"
+                  unoptimized
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-moonbeem-navy to-black text-body font-semibold text-moonbeem-ink-subtle">
+                  {ep.episode_number}
+                </div>
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="text-caption text-moonbeem-ink-subtle">
+                Episode {ep.episode_number}
+              </div>
+              <div className="truncate text-body-sm font-medium text-moonbeem-ink group-hover:text-moonbeem-pink">
+                {label}
+              </div>
+            </div>
+            <span
+              aria-hidden
+              className="pr-1 text-body text-moonbeem-ink-subtle group-hover:text-moonbeem-pink"
+            >
+              ▶
+            </span>
+          </button>
+        );
+      })}
+      <EpisodeModal episode={openEpisode} onClose={() => setOpenEpisode(null)} />
+    </div>
+  );
+}

--- a/src/components/EpisodeModal.tsx
+++ b/src/components/EpisodeModal.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { InstagramEmbed } from "react-social-media-embed";
+import type { TitleEpisode } from "@/lib/queries/titles";
+
+// Standalone episode player. Reuses the Instagram embed render path from
+// FanEditModal's EmbedFor (case "instagram") — fed ONLY an IG URL, with
+// NO fan_edits coupling and NO analytics (no fan_edit_events writes). The
+// embed is Instagram's public embed.js (tokenless). Single-episode for
+// v1; prev/next is banked. FanEditModal is left entirely untouched.
+export default function EpisodeModal({
+  episode,
+  onClose,
+}: {
+  episode: TitleEpisode | null;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    if (!episode) return;
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.body.style.overflow = prevOverflow;
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [episode, onClose]);
+
+  const stop = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
+
+  return (
+    <AnimatePresence>
+      {episode && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={episode.label ?? `Episode ${episode.episode_number}`}
+          className="fixed inset-0 z-50 flex items-stretch justify-center md:items-center"
+        >
+          <motion.div
+            key="backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.22, ease: "easeOut" }}
+            onClick={onClose}
+            className="absolute inset-0 bg-black/85 backdrop-blur-md"
+          />
+          <motion.div
+            key="dialog"
+            initial={{ opacity: 0, scale: 0.98 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.98 }}
+            transition={{ duration: 0.22, ease: "easeOut" }}
+            onClick={stop}
+            className="relative z-10 flex h-full w-full flex-col bg-moonbeem-black md:h-auto md:max-h-[90vh] md:w-auto md:max-w-[440px] md:overflow-hidden md:rounded-2xl md:border md:border-white/10 md:shadow-2xl md:shadow-black/60"
+          >
+            <div className="flex items-center justify-between gap-3 border-b border-white/10 px-4 py-3">
+              <span className="truncate text-body-sm font-medium text-moonbeem-ink">
+                {episode.label ?? `Episode ${episode.episode_number}`}
+              </span>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close"
+                className="flex h-11 w-11 items-center justify-center rounded-md text-body text-moonbeem-ink-subtle hover:text-moonbeem-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-moonbeem-pink"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="flex flex-1 items-start justify-center overflow-y-auto bg-moonbeem-navy/20 p-3">
+              <div className="w-full max-w-[400px]">
+                <InstagramEmbed
+                  url={episode.embed_url}
+                  width="100%"
+                  retryDelay={1000}
+                  placeholderDisabled
+                />
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/TitleTabs.tsx
+++ b/src/components/TitleTabs.tsx
@@ -4,12 +4,16 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useState, type ReactNode } from "react";
 import { fadeIn } from "@/lib/motion";
 
-type SectionId = "about" | "fan-edits" | "videos" | "stills";
+type SectionId = "about" | "watch" | "fan-edits" | "videos" | "stills";
 
 type Section = { id: SectionId; label: string; content: ReactNode };
 
 type Props = {
   aboutContent: ReactNode;
+  // Optional — when provided (the title has published episodes), a
+  // "Watch" tab is inserted after About. Absent/null → no Watch tab
+  // (same empty-guard discipline as the homepage Series rail).
+  watchContent?: ReactNode;
   fanEditsContent: ReactNode;
   videosContent: ReactNode;
   stillsContent: ReactNode;
@@ -17,6 +21,7 @@ type Props = {
 
 export default function TitleTabs({
   aboutContent,
+  watchContent,
   fanEditsContent,
   videosContent,
   stillsContent,
@@ -25,6 +30,9 @@ export default function TitleTabs({
 
   const sections: Section[] = [
     { id: "about", label: "About", content: aboutContent },
+    ...(watchContent != null
+      ? [{ id: "watch" as SectionId, label: "Watch", content: watchContent }]
+      : []),
     { id: "fan-edits", label: "Fan Edits", content: fanEditsContent },
     { id: "videos", label: "Clips", content: videosContent },
     { id: "stills", label: "Stills", content: stillsContent },

--- a/src/lib/queries/titles.ts
+++ b/src/lib/queries/titles.ts
@@ -241,6 +241,39 @@ export async function getSeriesTitles(): Promise<Title[]> {
   return data as Title[];
 }
 
+export type TitleEpisode = {
+  id: string;
+  title_id: string;
+  episode_number: number;
+  label: string | null;
+  embed_url: string;
+  source: string;
+  access: string;
+  cover_image_url: string | null;
+  is_published: boolean;
+};
+
+// Published episodes for a title's Watch tab, in episode order. Reads
+// via the service-role client (title_episodes is RLS-enabled with no
+// policies — service-role only — matching getAllFilms/getSeriesTitles
+// and the campaigns family). Episode visibility rides on the title
+// page's own canViewTitle gate.
+export async function getTitleEpisodes(
+  titleId: string,
+): Promise<TitleEpisode[]> {
+  const supabase = createServiceRoleClient();
+  const { data, error } = await supabase
+    .from("title_episodes")
+    .select(
+      "id, title_id, episode_number, label, embed_url, source, access, cover_image_url, is_published",
+    )
+    .eq("title_id", titleId)
+    .eq("is_published", true)
+    .order("episode_number", { ascending: true });
+  if (error || !data) return [];
+  return data as TitleEpisode[];
+}
+
 export type TitleOffer = {
   id: string;
   title_id: string;

--- a/supabase/migrations/20260606000001_title_episodes.sql
+++ b/supabase/migrations/20260606000001_title_episodes.sql
@@ -1,0 +1,49 @@
+-- Watch tab v1: title_episodes — an ordered list of a title's playable
+-- episodes (free Instagram embeds for now). Additive: a single new
+-- table, no ALTER to titles, reversible via DROP TABLE.
+--
+-- source/access are single-value CHECKs today, written DROP-then-ADD by
+-- name (the media_type pattern) so a later 'mux'/'paid' is a one-line
+-- constraint swap.
+--
+-- RLS is enabled with NO policies — service-role only, matching
+-- getAllFilms/getSeriesTitles and the campaigns family. Reads go through
+-- getTitleEpisodes (createServiceRoleClient); episode visibility rides on
+-- the title page's own canViewTitle gate. No anon/authenticated access.
+
+create table if not exists public.title_episodes (
+  id uuid primary key default gen_random_uuid(),
+  title_id uuid not null references public.titles(id) on delete cascade,
+  episode_number integer not null,
+  label text,
+  embed_url text not null,
+  source text not null default 'instagram',
+  access text not null default 'free',
+  cover_image_url text,
+  is_published boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  -- One row per (title, episode_number). The backing unique index also
+  -- serves the Watch-tab read (WHERE title_id=$1 ORDER BY episode_number
+  -- ASC), so a separate plain index on the same columns is intentionally
+  -- omitted as redundant.
+  constraint title_episodes_title_episode_unique unique (title_id, episode_number)
+);
+
+alter table public.title_episodes
+  drop constraint if exists title_episodes_source_check;
+alter table public.title_episodes
+  add constraint title_episodes_source_check check (source in ('instagram'));
+
+alter table public.title_episodes
+  drop constraint if exists title_episodes_access_check;
+alter table public.title_episodes
+  add constraint title_episodes_access_check check (access in ('free'));
+
+alter table public.title_episodes enable row level security;
+-- No policies. Service-role only.
+
+drop trigger if exists set_updated_at_title_episodes on public.title_episodes;
+create trigger set_updated_at_title_episodes
+  before update on public.title_episodes
+  for each row execute function public.set_updated_at();


### PR DESCRIPTION
## Watch tab v1 — free episode playback

Adds an optional **Watch** tab (between About and Fan Edits) that plays a title's episodes via the existing tokenless Instagram embed path.

- **`title_episodes`** table (migration `20260606000001`): FK→titles ON DELETE CASCADE, `UNIQUE(title_id,episode_number)`, named `source`/`access` CHECKs (media_type DROP/ADD pattern, so `mux`/`paid` later is a one-line swap), RLS-enabled-no-policies (service-role), house `set_updated_at` trigger. Additive; `DROP TABLE`-reversible.
- **`getTitleEpisodes(titleId)`** — published episodes in order (service-role, like getAllFilms/getSeriesTitles).
- **`EpisodeList`** — ordered vertical list; null cover → numbered tile (no broken image). **`EpisodeModal`** — standalone IG player reusing `InstagramEmbed`, **no fan_edits coupling, no analytics**.
- **`TitleTabs`/title page** — Watch tab inserted only when episodes exist (guarded on zero).

**FanEditModal/Provider/FanEditsTab/fan_edits untouched.** No entitlement work (free path). Verified on prod data: migration applied; `source='mux'` rejected by the CHECK; Watch tab present on a 3-episode test title (between About & Fan Edits), absent on a zero-episode title; episode query returns ordered rows; test data torn down (0 rows). `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)