### PR TITLE
Events content type (event-as-title): media_type 'event' + Events rail + event title page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import {
   getAllFilms,
+  getEventTitles,
   getFeaturedTitles,
   getRecentFanEdits,
   getSeriesTitles,
@@ -28,6 +29,7 @@ export default async function Home() {
     trending,
     activeCampaignTitles,
     series,
+    events,
   ] = await Promise.all([
     getHomepageSectionOrder(),
     getFeaturedTitles(),
@@ -37,6 +39,7 @@ export default async function Home() {
     getTrendingFanEdits(12),
     getTitlesWithActiveCampaigns(),
     getSeriesTitles(),
+    getEventTitles(),
   ]);
 
   // Renderer-per-slug — keeps the conditional length>0 guard
@@ -100,6 +103,31 @@ export default async function Home() {
       rendered.splice(afterAllFilms + 1, 0, seriesEntry);
     } else {
       rendered.push(seriesEntry);
+    }
+  }
+  // Events rail — clones the Series shelf for event-as-title content
+  // (media_type='event', e.g. Sukeban matches). Same out-of-taxonomy
+  // approach as Series (no homepage_sections slug, so no CHECK / reorder
+  // route / migration to touch). Splices AFTER the Series node when
+  // present, else after all-films, else pushes — yielding the order
+  // All Films → Series → Events. Runs after the Series splice above so
+  // the "series" node already exists in `rendered`. Guarded on empty so
+  // there's no "Events" header on an empty shelf.
+  if (events.length > 0) {
+    const eventsEntry = {
+      slug: "events",
+      node: <TitleCarousel title="Events" titles={events} />,
+    };
+    const afterSeries = rendered.findIndex((r) => r.slug === "series");
+    const afterAllFilmsForEvents = rendered.findIndex(
+      (r) => r.slug === "all-films",
+    );
+    if (afterSeries >= 0) {
+      rendered.splice(afterSeries + 1, 0, eventsEntry);
+    } else if (afterAllFilmsForEvents >= 0) {
+      rendered.splice(afterAllFilmsForEvents + 1, 0, eventsEntry);
+    } else {
+      rendered.push(eventsEntry);
     }
   }
   const visibleIndexes = rendered

--- a/src/app/t/[slug]/page.tsx
+++ b/src/app/t/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
   isTitleInActiveCampaign,
   type TitleOffer,
 } from "@/lib/queries/titles";
+import { getPartnerById } from "@/lib/queries/partners";
 import TitleTabs from "@/components/TitleTabs";
 import EpisodeList from "@/components/EpisodeList";
 import FanEditsTab from "@/components/FanEditsTab";
@@ -30,6 +31,32 @@ import { getUsageCount } from "@/lib/gating/usage-counts";
 import { Suspense } from "react";
 
 type PageProps = { params: Promise<{ slug: string }> };
+
+// Render a stored event_date (timestamptz) readably for the event meta
+// line. Date always shown; time appended only when the stored value
+// carries a non-midnight-UTC time component (Dan stores date-only as
+// 00:00). Formatted in UTC for SSR determinism — timezone-perfect local
+// display is a populate-time refinement, not this build. Returns null for
+// null/unparseable input so the caller can omit the segment entirely.
+function formatEventDate(iso: string | null): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  const dateStr = d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+  const hasTime = d.getUTCHours() !== 0 || d.getUTCMinutes() !== 0;
+  if (!hasTime) return dateStr;
+  const timeStr = d.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC",
+  });
+  return `${dateStr} · ${timeStr}`;
+}
 
 export async function generateMetadata({
   params,
@@ -125,6 +152,17 @@ export default async function TitlePage({ params }: PageProps) {
       isTitleInActiveCampaign(title.id),
       getTitleEpisodes(title.id),
     ]);
+
+  // Event-only: fetch the title's partner (the league) for the header
+  // logo treatment. Conditional so films/series never pay for this read,
+  // and so getTitleBySlug stays untouched. Fallback chain handled in the
+  // header JSX: logo_url → name text → nothing.
+  const eventPartner =
+    title.media_type === "event" && title.partner_id
+      ? await getPartnerById(title.partner_id)
+      : null;
+  const eventDateDisplay =
+    title.media_type === "event" ? formatEventDate(title.event_date) : null;
 
   const supabase = await createClient();
   const {
@@ -226,6 +264,30 @@ export default async function TitlePage({ params }: PageProps) {
 
         <div className="w-full md:flex-1 md:min-w-0 flex flex-col items-center gap-8 md:items-stretch">
           <div className="flex flex-col items-center gap-3 max-w-prose text-center md:items-start md:text-left md:max-w-none">
+            {/* Event-only league/partner banner, "up top" above the
+                title — prominent but contained (≤64px tall). Fallback
+                chain: logo image → partner name as text → nothing.
+                Plain <img> matches the partner-logo convention
+                (PartnerLogoStrip) so the R2 host doesn't need a
+                next.config remotePatterns entry per uploaded logo. */}
+            {title.media_type === "event" &&
+              eventPartner &&
+              (eventPartner.logo_url || eventPartner.name) && (
+                <div className="flex w-full items-center justify-center md:justify-start">
+                  {eventPartner.logo_url ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={eventPartner.logo_url}
+                      alt={eventPartner.name}
+                      className="h-12 w-auto max-w-[240px] object-contain md:h-16"
+                    />
+                  ) : (
+                    <span className="font-wordmark text-display-sm text-moonbeem-ink-muted">
+                      {eventPartner.name}
+                    </span>
+                  )}
+                </div>
+              )}
             <h1 className="font-wordmark font-bold text-display-md md:text-display-lg text-moonbeem-pink m-0">
               {title.title}
             </h1>
@@ -234,6 +296,18 @@ export default async function TitlePage({ params }: PageProps) {
                 {metaParts.join(" · ")}
               </p>
             )}
+            {/* Event-only meta line: date · venue, reusing the film
+                meta styling. Renders only what exists (date and/or
+                venue); the film metaParts above stay empty for events
+                (director/year/runtime null → auto-suppressed). */}
+            {title.media_type === "event" &&
+              (eventDateDisplay || title.venue) && (
+                <p className="text-body text-moonbeem-ink-muted m-0">
+                  {[eventDateDisplay, title.venue]
+                    .filter(Boolean)
+                    .join(" · ")}
+                </p>
+              )}
             {title.distributor && (
               <p className="text-body-sm text-moonbeem-ink-subtle m-0">
                 Distributed by {title.distributor}

--- a/src/lib/queries/partners.ts
+++ b/src/lib/queries/partners.ts
@@ -36,3 +36,34 @@ export async function getMarqueePartners(): Promise<MarqueePartner[]> {
     )
     .map((r) => ({ slug: r.slug, name: r.name, logo_url: r.logo_url }));
 }
+
+export type PartnerSummary = {
+  id: string;
+  name: string;
+  logo_url: string | null;
+};
+
+// Scoped partner lookup by id — used by the EVENT title page to render the
+// league/partner logo "up top". No reusable partner-by-id getter existed
+// before this (only inline .from("partners") reads scattered across admin
+// routes). Service-role for the same RLS reason as getMarqueePartners
+// (partners has RLS on with no public SELECT policy). Returns name +
+// logo_url so the title page can do the logo_url → name-text → nothing
+// fallback chain. This is fetched ONLY for events; getTitleBySlug is not
+// modified.
+export async function getPartnerById(
+  id: string,
+): Promise<PartnerSummary | null> {
+  const supabase = createServiceRoleClient();
+  const { data, error } = await supabase
+    .from("partners")
+    .select("id, name, logo_url")
+    .eq("id", id)
+    .maybeSingle();
+  if (error || !data) return null;
+  return {
+    id: data.id as string,
+    name: data.name as string,
+    logo_url: (data.logo_url as string | null) ?? null,
+  };
+}

--- a/src/lib/queries/titles.ts
+++ b/src/lib/queries/titles.ts
@@ -33,6 +33,14 @@ export type Title = {
   is_public: boolean;
   is_featured: boolean;
   partner_id: string | null;
+  // Content-type discriminator (CHECK: movie | tv | event). Always present
+  // (select("*")); declared here so the title page can branch on
+  // media_type === 'event' without a cast.
+  media_type: string;
+  // Event-only fields (media_type='event'); null for movie/tv. Added by
+  // 20260606000002_titles_event_type.sql.
+  event_date: string | null;
+  venue: string | null;
   cast_members: CastMember[] | null;
   crew: CrewMember[] | null;
 };
@@ -235,6 +243,27 @@ export async function getSeriesTitles(): Promise<Title[]> {
     .eq("is_public", true)
     .eq("is_active", true)
     .eq("media_type", "tv")
+    .order("allfilms_pin_order", { ascending: true, nullsFirst: false })
+    .order("created_at", { ascending: false });
+  if (error || !data) return [];
+  return data as Title[];
+}
+
+// The event analog of getSeriesTitles — feeds the homepage "Events" rail
+// for event-as-title content (Sukeban-style, media_type='event'). Same
+// is_public + is_active gate and the SAME ordering as the films/series
+// catalog rails (allfilms_pin_order ASC NULLS LAST, then created_at DESC)
+// so the three shelves behave identically. Service-role client to match
+// getAllFilms/getSeriesTitles. Event-date-based ordering is a populate-
+// time refinement, intentionally not done here (mirror Series for v1).
+export async function getEventTitles(): Promise<Title[]> {
+  const supabase = createServiceRoleClient();
+  const { data, error } = await supabase
+    .from("titles")
+    .select("*")
+    .eq("is_public", true)
+    .eq("is_active", true)
+    .eq("media_type", "event")
     .order("allfilms_pin_order", { ascending: true, nullsFirst: false })
     .order("created_at", { ascending: false });
   if (error || !data) return [];

--- a/supabase/migrations/20260606000002_titles_event_type.sql
+++ b/supabase/migrations/20260606000002_titles_event_type.sql
@@ -1,0 +1,28 @@
+-- Events content type (event-as-title, e.g. Sukeban match = one title).
+-- Extends titles.media_type to allow 'event' alongside 'movie'/'tv', and
+-- adds two nullable event-only columns (event_date, venue).
+--
+-- Additive + reversible.
+--   * The CHECK swap triggers a one-time full-table revalidation scan
+--     under a brief ACCESS EXCLUSIVE lock (~1.4M rows). All existing rows
+--     are 'movie'/'tv' and pass; product is idle, so the lock is accepted.
+--   * The two column adds are metadata-only: nullable with NO default, so
+--     Postgres records the column in the catalog without rewriting the
+--     table (no per-row work).
+--   * No index, trigger (set_updated_at_titles / titles_person_names_sync),
+--     generated column, or dependent view (admin_title_request_stats) is
+--     affected by an ADD COLUMN.
+--
+-- Reverse:
+--   ALTER TABLE public.titles DROP COLUMN IF EXISTS venue;
+--   ALTER TABLE public.titles DROP COLUMN IF EXISTS event_date;
+--   ALTER TABLE public.titles DROP CONSTRAINT IF EXISTS titles_media_type_check;
+--   ALTER TABLE public.titles ADD CONSTRAINT titles_media_type_check
+--     CHECK (media_type = ANY (ARRAY['movie'::text, 'tv'::text]));
+
+ALTER TABLE public.titles DROP CONSTRAINT IF EXISTS titles_media_type_check;
+ALTER TABLE public.titles ADD CONSTRAINT titles_media_type_check
+  CHECK (media_type = ANY (ARRAY['movie'::text, 'tv'::text, 'event'::text]));
+
+ALTER TABLE public.titles ADD COLUMN IF NOT EXISTS event_date timestamptz;
+ALTER TABLE public.titles ADD COLUMN IF NOT EXISTS venue text;


### PR DESCRIPTION
Adds the **event-as-title** content type (Sukeban — wrestling/sports league; each match = one title, `media_type='event'`).

## Migration (applied to prod via apply_migration: `titles_event_type`)
- Extend `titles_media_type_check` → `movie | tv | event` (DROP/ADD; ~1.43M-row revalidation, all pass).
- Add nullable `event_date timestamptz` + `venue text` (metadata-only, no rewrite). Reversible (reverse DDL in the migration header).

## Code
- `getEventTitles` (mirrors `getSeriesTitles`) + `getPartnerById` (scoped partner-by-id for the event header logo).
- Homepage **Events rail** clones the Series shelf — splices after Series → All Films → Series → Events, guarded on empty.
- Event title page: events-only partner logo banner up top, `date · venue` meta line; film fields auto-suppress.
- `getTitleBySlug`, `getAllFilms`, `getSeriesTitles`/Series rail, `getFeaturedTitles`, campaigns rail — untouched. Partner fetch is events-only.

## Acceptance (prod, against a torn-down test event)
- CHECK proof: `event` accepted, `short` rejected by the constraint.
- Deterministic gate: `getEventTitles` ✓ returns it, `getAllFilms` ✗, `getFeaturedTitles` ✗.
- SSR render: Events rail (All Films → Events, Series currently empty); event page shows Oscilloscope logo + `June 14, 2026 · 7:30 PM · Test Arena`, all film fields suppressed, poster null → gradient fallback; film page unchanged (no banner).
- Test event torn down (0 events live); real Oscilloscope partner left fully intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)