### PR TITLE
FIX A: close withdrawal double-pay via needs_reconciliation status

### DIFF
--- a/docs/payout-reconciliation.md
+++ b/docs/payout-reconciliation.md
@@ -1,0 +1,98 @@
+# Payout reconciliation — `needs_reconciliation` withdrawals (FIX A)
+
+A creator withdrawal (`src/app/api/me/payouts/withdraw/route.ts`) moves money in
+two steps that are **not** in one transaction:
+
+1. `stripe.transfers.create(...)` — money leaves the platform balance, then
+2. stamping `creator_earnings.withdrawn_at` on the settled rows.
+
+If step 1 succeeds but step 2 fails, the route parks the withdrawal in
+**`needs_reconciliation`** (instead of `completed`): the money has moved, but the
+earnings are still `withdrawn_at IS NULL`. The re-entry guard blocks that creator
+from withdrawing again — which would re-sum and re-pay the same earnings (the
+double-pay this status prevents) — so each stuck row must be cleared **by hand**
+using the steps below. This is the operational recovery path until **FIX B** (a
+structural `creator_earnings.withdrawal_id` link + an automatic reconciler) ships.
+
+## 1. Find the stuck withdrawal(s)
+
+```sql
+select id, creator_id, amount_cents, status, stripe_transfer_id,
+       created_at, completed_at
+from public.withdrawals
+where status = 'needs_reconciliation'
+order by created_at desc;
+```
+
+Note the `id` (withdrawal id) and `stripe_transfer_id`.
+
+## 2. Identify the earnings that failed to stamp
+
+**Preferred** — read the route's server log for the matching line; it lists the
+exact ids:
+
+```
+[payouts] RECONCILE-REQUIRED withdrawal=<id> transfer=<tr_id> stamp failed
+  AFTER successful transfer (money moved, earnings NOT stamped): <err>;
+  unstamped earnings_ids=[<uuid>,<uuid>,...]
+```
+
+**Fallback** if the log is unavailable — the creator's still-unstamped earnings
+as of the withdrawal. Sanity-check that the sum equals the withdrawal's
+`amount_cents` before acting:
+
+```sql
+select id, earnings_cents, created_at
+from public.creator_earnings
+where creator_id = '<creator_id>'
+  and withdrawn_at is null
+  and created_at <= '<withdrawal.created_at>'
+order by created_at;
+-- sum(earnings_cents) here should equal the withdrawal's amount_cents.
+```
+
+## 3. Verify in Stripe that the transfer actually settled (READ-ONLY)
+
+Confirm the transfer exists and matches before stamping anything. Use the
+appropriate key (TEST or LIVE); **do not create anything**.
+
+```
+stripe transfers retrieve <stripe_transfer_id>
+```
+
+Confirm `amount` == the withdrawal's `amount_cents` and `destination` == the
+creator's connected account (`creator_payout_accounts.stripe_connect_account_id`).
+
+## 4. Reconcile (only after step 3 confirms the money moved)
+
+```sql
+-- 4a. Stamp the earnings the transfer paid (ids from step 2):
+update public.creator_earnings
+set withdrawn_at = now()
+where id in ('<uuid>', '<uuid>', ...)
+  and withdrawn_at is null;
+
+-- 4b. Close out the withdrawal:
+update public.withdrawals
+set status = 'completed', completed_at = now()
+where id = '<withdrawal_id>'
+  and status = 'needs_reconciliation';
+```
+
+After 4b the re-entry guard no longer blocks the creator, and their available
+balance drops by the reconciled amount on the next read.
+
+## 5. Notes
+
+- If step 3 shows the transfer did **not** move money, do the opposite: leave the
+  earnings unstamped and set the withdrawal to `failed` so the creator can retry:
+  ```sql
+  update public.withdrawals
+  set status = 'failed', completed_at = now()
+  where id = '<withdrawal_id>' and status = 'needs_reconciliation';
+  ```
+- **FIX B (durable follow-up, not this change):** add
+  `creator_earnings.withdrawal_id uuid` (FK → `withdrawals`), claim it atomically
+  at selection time, exclude claimed rows in both selection and the balance
+  reads (`/api/me/payouts/status`, `/me`), and add an admin reconcile UI / auto
+  reconciler — which removes the manual steps above.

--- a/src/app/api/me/payouts/withdraw/route.ts
+++ b/src/app/api/me/payouts/withdraw/route.ts
@@ -8,18 +8,27 @@
 //
 // Flow:
 //   1. Validate caller has creator + payout account + payouts_enabled.
-//   2. Reject if any pending withdrawal exists (ui already disables
-//      the button, this is defensive).
+//   2. Reject if a withdrawal is already in flight ('pending') OR parked
+//      in 'needs_reconciliation' (a prior stamp failure — see step 7a).
 //   3. Compute the available balance from unwithdrawn earnings.
 //   4. Reject if balance < MIN_WITHDRAWAL_CENTS.
 //   5. Insert a withdrawal row in 'pending'.
 //   6. Call stripe.transfers.create with the withdrawal id as
 //      idempotency key — guards against double-clicks.
-//   7. On Stripe success: stamp withdrawn_at on the earnings rows
-//      we just settled, mark withdrawal completed with the
-//      transfer id.
-//   8. On Stripe failure: mark withdrawal failed; earnings rows
-//      stay unwithdrawn so the user can retry.
+//   7. On Stripe success + earnings-stamp success: mark withdrawal
+//      'completed' with the transfer id. (This is the ONLY path to
+//      'completed'.)
+//   7a. On Stripe success but earnings-stamp FAILURE: money moved but the
+//      earnings are still withdrawn_at NULL — park the withdrawal in
+//      'needs_reconciliation' (NOT 'completed'), record the transfer id,
+//      leave completed_at null, and return a non-success response. The
+//      step-2 guard then blocks this creator's future withdrawals until an
+//      admin reconciles by hand (docs/payout-reconciliation.md). This is
+//      FIX A, closing the double-pay window; FIX B (a structural
+//      creator_earnings.withdrawal_id link + auto reconciler) is the
+//      durable follow-up.
+//   8. On Stripe failure (transfer throw): mark withdrawal 'failed';
+//      earnings stay unwithdrawn so the user can retry (no money moved).
 
 import { NextResponse } from "next/server";
 import type Stripe from "stripe";
@@ -60,22 +69,32 @@ export async function POST() {
     });
   }
 
-  // Reject if a withdrawal is already in flight. Race window: two
-  // simultaneous POSTs could both pass this check; the idempotency
-  // key on the Stripe call protects against double-transfer, and
-  // the second insert would fail uniquely if we add a partial-unique
-  // constraint later. For v1 the UI disables the button; this is a
-  // backstop.
-  const { data: pending } = await supabase
+  // Reject if a withdrawal is already in flight ('pending') OR if a prior
+  // withdrawal is parked in 'needs_reconciliation'. The latter means a
+  // transfer SUCCEEDED but the earnings stamp failed, so those earnings are
+  // still withdrawn_at NULL — letting a new withdrawal through would re-sum
+  // and re-pay them (double-pay). Blocking on both statuses is FIX A: the
+  // creator stays blocked until an admin clears the stuck row by hand
+  // (docs/payout-reconciliation.md). Race window: two simultaneous POSTs
+  // could both pass this check; the idempotency key on the Stripe call
+  // backstops a double-transfer. For v1 the UI disables the button too.
+  const { data: blocking } = await supabase
     .from("withdrawals")
-    .select("id")
+    .select("id, status")
     .eq("creator_id", creator.id)
-    .eq("status", "pending")
+    .in("status", ["pending", "needs_reconciliation"])
     .limit(1);
-  if ((pending ?? []).length > 0) {
-    return NextResponse.json({ error: "pending_withdrawal_in_flight" }, {
-      status: 409,
-    });
+  if ((blocking ?? []).length > 0) {
+    const blockedStatus = (blocking![0].status as string) ?? "pending";
+    return NextResponse.json(
+      {
+        error:
+          blockedStatus === "needs_reconciliation"
+            ? "withdrawal_needs_reconciliation"
+            : "pending_withdrawal_in_flight",
+      },
+      { status: 409 },
+    );
   }
 
   // Snapshot the rows we're about to settle. Doing this BEFORE the
@@ -158,23 +177,57 @@ export async function POST() {
     );
   }
 
-  // Stripe succeeded. Stamp withdrawn_at on the earnings rows we
-  // settled (clamp to the snapshotted ids — a row that landed
-  // between snapshot and now stays unwithdrawn for the next call).
+  // Stripe succeeded — the money has moved to the connected account. Stamp
+  // withdrawn_at on the earnings rows we settled (clamp to the snapshotted
+  // ids — a row that landed between snapshot and now stays unwithdrawn for
+  // the next call). This is a single UPDATE … WHERE id IN (…): all-or-nothing
+  // for the batch.
   const withdrawnAt = new Date().toISOString();
   const { error: stampErr } = await supabase
     .from("creator_earnings")
     .update({ withdrawn_at: withdrawnAt })
     .in("id", earningsIdsToSettle);
+
   if (stampErr) {
-    // Money has already moved. We log loudly but still report
-    // success to the user; the reconciliation job (future work)
-    // will re-stamp from withdrawals.completed_at.
+    // DOUBLE-PAY GUARD (FIX A). The transfer SUCCEEDED but we could not stamp
+    // withdrawn_at, so these earnings are still withdrawn_at NULL. We must NOT
+    // mark this 'completed' and must NOT report clean success — either would
+    // let the creator withdraw again and re-pay the same earnings. Park the
+    // row in 'needs_reconciliation' (money moved → record the transfer id;
+    // completed_at stays null because it is NOT complete). The step-2 re-entry
+    // guard blocks this creator's future withdrawals until an admin reconciles
+    // the row by hand. Manual-clear steps: docs/payout-reconciliation.md.
+    // (FIX B — a structural creator_earnings.withdrawal_id link + an auto
+    // reconciler — is the durable follow-up, not this change.)
     console.error(
-      `[payouts] stamp earnings failed for withdrawal=${withdrawalId} after successful transfer=${transfer.id}: ${stampErr.message}`,
+      `[payouts] RECONCILE-REQUIRED withdrawal=${withdrawalId} transfer=${transfer.id} ` +
+        `stamp failed AFTER successful transfer (money moved, earnings NOT stamped): ${stampErr.message}; ` +
+        `unstamped earnings_ids=[${earningsIdsToSettle.join(",")}]`,
+    );
+    await supabase
+      .from("withdrawals")
+      .update({
+        status: "needs_reconciliation",
+        stripe_transfer_id: transfer.id,
+        completed_at: null,
+      })
+      .eq("id", withdrawalId);
+    return NextResponse.json(
+      {
+        ok: false,
+        needs_reconciliation: true,
+        withdrawal_id: withdrawalId,
+        stripe_transfer_id: transfer.id,
+        amount_cents: totalCents,
+        detail:
+          "Your payout was sent but our records need a manual check. " +
+          "It will be reconciled shortly — no further action is needed.",
+      },
+      { status: 202 },
     );
   }
 
+  // Stamp succeeded — this is the ONLY path to 'completed'.
   await supabase
     .from("withdrawals")
     .update({

--- a/supabase/migrations/20260606000003_withdrawals_needs_reconciliation_status.sql
+++ b/supabase/migrations/20260606000003_withdrawals_needs_reconciliation_status.sql
@@ -1,0 +1,26 @@
+-- FIX A — close the creator-withdrawal double-pay window with a blocking
+-- reconciliation status.
+--
+-- A withdrawal moves money in two NON-atomic steps (not in one transaction):
+--   1. stripe.transfers.create(...)  → money leaves the platform balance
+--   2. stamp creator_earnings.withdrawn_at on the settled rows
+-- If step 1 succeeds but step 2 fails, the route used to mark the withdrawal
+-- 'completed' while the earnings stayed withdrawn_at NULL — so the creator
+-- could withdraw again and re-pay the same earnings (double-pay). The route
+-- now parks that row in 'needs_reconciliation' instead, and the re-entry guard
+-- blocks the creator's future withdrawals until an admin clears it by hand
+-- (docs/payout-reconciliation.md). FIX B (a structural
+-- creator_earnings.withdrawal_id link + auto reconciler) is the durable
+-- follow-up; this migration only adds the new allowed status value.
+--
+-- Additive + reversible. `withdrawals` is a tiny table; every existing row is
+-- 'pending'/'completed'/'failed', so all pass the widened CHECK (trivial scan).
+--
+-- Reverse (ONLY once no row uses the new value):
+--   ALTER TABLE public.withdrawals DROP CONSTRAINT withdrawals_status_check;
+--   ALTER TABLE public.withdrawals ADD CONSTRAINT withdrawals_status_check
+--     CHECK (status IN ('pending', 'completed', 'failed'));
+
+ALTER TABLE public.withdrawals DROP CONSTRAINT IF EXISTS withdrawals_status_check;
+ALTER TABLE public.withdrawals ADD CONSTRAINT withdrawals_status_check
+  CHECK (status IN ('pending', 'completed', 'failed', 'needs_reconciliation'));


### PR DESCRIPTION
Closes the confirmed creator-withdrawal **double-pay** window.

## Problem
`stripe.transfers.create` and the `creator_earnings.withdrawn_at` stamp are not atomic. If the transfer succeeds but the stamp throws, the route used to mark the withdrawal `completed` while the earnings stayed `withdrawn_at NULL` — so a later withdrawal re-summed and re-paid them (double-pay).

## Fix (surgical)
- **Migration** (`20260606000003`): widen `withdrawals_status_check` to allow `needs_reconciliation` (additive, reversible; 2-row table).
- **Route** (`withdraw/route.ts`): on a stamp failure after a successful transfer, park the row in `needs_reconciliation` (record `stripe_transfer_id`, `completed_at` null), emit a greppable `RECONCILE-REQUIRED` log with the unstamped earnings ids, and return `202 {ok:false}`. `completed` is now reachable **only** on stamp success. The re-entry guard blocks on both `pending` and `needs_reconciliation`. Transfer-throw path (`failed`, no money moved) unchanged.
- **Runbook** (`docs/payout-reconciliation.md`): manual-clear steps until FIX B.

## Acceptance (prod, TEST mode, no Stripe writes)
- CHECK probe: `needs_reconciliation` accepted, `frozen` rejected; pending/completed/failed intact.
- Guard test (DB-simulated on a torn-down scratch row): blocks on `needs_reconciliation` (409 `withdrawal_needs_reconciliation`), clears when set to `completed`. Scratch row fully removed; Dan's 2 real withdrawals left intact and unblocked.
- Code-path: only path to `completed` is stamp-success; stampErr returns 202 early.

FIX B (structural `creator_earnings.withdrawal_id` + auto reconciler) is the durable follow-up, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)