### PR TITLE
Follow feature (Steps 1–3): graph + server layer + button on /c/[handle]

### DIFF
--- a/src/app/api/follows/route.ts
+++ b/src/app/api/follows/route.ts
@@ -1,0 +1,101 @@
+// Follow feature — Step 3: write route. A THIN wrapper over the self-resolving
+// Step 2 functions. Policy (rate-limit) lives here; the actor is resolved INSIDE
+// followCreator/unfollowCreator from the session. This route passes ONLY the
+// client-supplied target_creator_id and never an actor — that asymmetry is the
+// structural forged-follow guard.
+//
+//   POST   /api/follows  { target_creator_id }  → follow
+//   DELETE /api/follows  { target_creator_id }  → unfollow
+
+import { NextResponse, type NextRequest } from "next/server";
+import { getUser } from "@/lib/dal";
+import { enforce } from "@/lib/ratelimit";
+import {
+  followCreator,
+  unfollowCreator,
+  type FollowOutcome,
+} from "@/lib/follows/server";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Map the FollowOutcome union to HTTP. reason is ALWAYS in the body so the
+// client branches on it (success / auth_required → sign-in / no_creator →
+// onboarding / everything else → inline error). no_creator stays distinct from
+// a generic error — it's a conversion prompt, not a failure.
+function outcomeToResponse(outcome: FollowOutcome): NextResponse {
+  if (outcome.ok) {
+    return NextResponse.json({
+      ok: true,
+      isFollowing: outcome.isFollowing,
+      followerCount: outcome.followerCount,
+    });
+  }
+  const status =
+    outcome.reason === "auth_required"
+      ? 401
+      : outcome.reason === "no_creator"
+        ? 403
+        : outcome.reason === "self_follow"
+          ? 400
+          : outcome.reason === "target_not_found"
+            ? 404
+            : 500;
+  return NextResponse.json({ ok: false, reason: outcome.reason }, { status });
+}
+
+async function handle(
+  request: NextRequest,
+  op: "follow" | "unfollow",
+): Promise<NextResponse> {
+  // Cheap auth gate + a stable rate-limit key BEFORE any DB work. Anon callers
+  // never reach the limiter or the DB.
+  const user = await getUser();
+  if (!user) {
+    return NextResponse.json(
+      { ok: false, reason: "auth_required" },
+      { status: 401 },
+    );
+  }
+
+  // RATE LIMIT — reuse the established mutation tier (userWrites = 30/min/user).
+  // A follow is a cheap, scriptable write on a public graph; this is the cap
+  // that blocks scripted mass-follow (count inflation now, notification-spam
+  // later). Per-user key, sliding window. enforce() fails open on Upstash
+  // outage by design.
+  const rl = await enforce("userWrites", user.id, `follows:${op}`);
+  if (!rl.ok) return rl.response;
+
+  let body: { target_creator_id?: string };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json(
+      { ok: false, reason: "error" },
+      { status: 400 },
+    );
+  }
+  const target = (body.target_creator_id ?? "").trim();
+  if (!UUID_RE.test(target)) {
+    return NextResponse.json(
+      { ok: false, reason: "target_not_found" },
+      { status: 404 },
+    );
+  }
+
+  // ONLY the target is passed. The actor is resolved inside the function from
+  // the session — never threaded from the request.
+  const outcome =
+    op === "follow"
+      ? await followCreator(target)
+      : await unfollowCreator(target);
+  return outcomeToResponse(outcome);
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  return handle(request, "follow");
+}
+
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  return handle(request, "unfollow");
+}

--- a/src/app/c/[handle]/page.tsx
+++ b/src/app/c/[handle]/page.tsx
@@ -7,6 +7,7 @@ import { getFanEditsForCreator } from "@/lib/queries/titles";
 import { getPublicDiaryForCreator } from "@/lib/queries/diary";
 import { getPublicListsForCreator } from "@/lib/queries/lists";
 import { getWatchedCountForCreator } from "@/lib/queries/watched";
+import { getViewerFollowContext } from "@/lib/follows/server";
 import ProfileView from "@/components/profile/ProfileView";
 
 export default async function ProfilePage({
@@ -32,17 +33,24 @@ export default async function ProfilePage({
         fanEdits={[]}
         watchedCount={0}
         isOwner={false}
+        followState="anon"
+        isFollowing={false}
       />
     );
   }
 
-  const [topTitles, fanEdits, diary, lists, watchedCount] = await Promise.all([
-    getTopTitlesForUser(profile.user_id),
-    getFanEditsForCreator(profile.creator_id),
-    getPublicDiaryForCreator(profile.creator_id, 20, !!currentUser),
-    getPublicListsForCreator(profile.creator_id),
-    getWatchedCountForCreator(profile.creator_id),
-  ]);
+  // Follow context folds in as one more PARALLEL entry — no serial round trip.
+  // Anon viewers fire zero queries inside it; logged-in viewers cost one
+  // resolveCreatorId (+ one follows probe only when claimed).
+  const [topTitles, fanEdits, diary, lists, watchedCount, followContext] =
+    await Promise.all([
+      getTopTitlesForUser(profile.user_id),
+      getFanEditsForCreator(profile.creator_id),
+      getPublicDiaryForCreator(profile.creator_id, 20, !!currentUser),
+      getPublicListsForCreator(profile.creator_id),
+      getWatchedCountForCreator(profile.creator_id),
+      getViewerFollowContext(currentUser?.userId ?? null, profile.creator_id),
+    ]);
   const isOwner = currentUser?.userId === profile.user_id;
 
   return (
@@ -55,6 +63,8 @@ export default async function ProfilePage({
       fanEdits={fanEdits}
       watchedCount={watchedCount}
       isOwner={isOwner}
+      followState={followContext.followState}
+      isFollowing={followContext.isFollowing}
     />
   );
 }

--- a/src/components/profile/FollowButton.tsx
+++ b/src/components/profile/FollowButton.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+// Follow feature — Step 3: the Follow button + its adjacent follower/following
+// stat line on /c/[handle]. Client child of the server profile page, rendered
+// ONLY for non-owners (the page omits this island entirely when isOwner, so
+// own-profile hiding is decided server-side). Owners get a static server byline
+// instead — see ProfileView.
+//
+// Five states, resolved server-side and passed in (no round trip on load, no
+// probe on click for anon/no_creator):
+//   own profile → this island is NOT rendered at all (server-gated)
+//   "anon"      → "Follow"; click opens the auth GateModal (sign-in)
+//   "no_creator"→ "Follow"; click routes to /onboarding/handle (conversion)
+//   "ready" + not following → "Follow"; click follows (optimistic)
+//   "ready" + following     → "Following"; click unfollows (optimistic)
+//
+// The stat line and button share one optimistic follower count so the count
+// adjusts the instant the button flips. followingCount is this profile's own
+// following total and is unaffected by the viewer's action, so it stays static.
+// Mirrors TitleRatingControl: optimistic flip + inline error revert (no toast
+// library in the repo), GateModal for auth_required.
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import GateModal from "@/components/gating/GateModal";
+import { fetchJson, FetchJsonError } from "@/lib/fetch-json";
+import type { FollowState } from "@/lib/follows/server";
+
+// Shared so the static owner byline (ProfileView) is byte-identical.
+export const FOLLOW_STAT_CLASS = "text-caption text-moonbeem-ink-subtle";
+
+export function followStatText(followers: number, following: number): string {
+  return `${followers.toLocaleString()} ${
+    followers === 1 ? "follower" : "followers"
+  } · ${following.toLocaleString()} following`;
+}
+
+type FollowResponse = {
+  ok: boolean;
+  isFollowing?: boolean;
+  followerCount?: number;
+  reason?: string;
+};
+
+export default function FollowButton({
+  targetCreatorId,
+  initialIsFollowing,
+  initialFollowerCount,
+  followingCount,
+  followState,
+  returnTo,
+}: {
+  targetCreatorId: string;
+  initialIsFollowing: boolean;
+  initialFollowerCount: number;
+  followingCount: number;
+  followState: FollowState;
+  returnTo: string;
+}) {
+  const router = useRouter();
+  const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
+  const [count, setCount] = useState(initialFollowerCount);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [gateOpen, setGateOpen] = useState(false);
+
+  async function onClick() {
+    if (pending) return; // debounce fast double-clicks (server is idempotent anyway)
+
+    // Anon / unclaimed are known up front — route immediately, no fetch.
+    if (followState === "anon") {
+      setGateOpen(true);
+      return;
+    }
+    if (followState === "no_creator") {
+      router.push(`/onboarding/handle?next=${encodeURIComponent(returnTo)}`);
+      return;
+    }
+
+    const nextFollowing = !isFollowing;
+    const prevFollowing = isFollowing;
+    const prevCount = count;
+
+    // Optimistic flip + immediate count adjust.
+    setIsFollowing(nextFollowing);
+    setCount((c) => Math.max(0, c + (nextFollowing ? 1 : -1)));
+    setError(null);
+    setPending(true);
+
+    try {
+      const data = await fetchJson<FollowResponse>("/api/follows", {
+        method: nextFollowing ? "POST" : "DELETE",
+        body: { target_creator_id: targetCreatorId },
+      });
+      // Settle on server truth (read-back of the denormalized column).
+      if (typeof data.isFollowing === "boolean") setIsFollowing(data.isFollowing);
+      if (typeof data.followerCount === "number") setCount(data.followerCount);
+    } catch (err) {
+      // Roll back the optimistic flip first, then branch.
+      setIsFollowing(prevFollowing);
+      setCount(prevCount);
+      if (err instanceof FetchJsonError) {
+        const reason =
+          err.payload && typeof err.payload === "object"
+            ? (err.payload as { reason?: string }).reason
+            : undefined;
+        // Session changed since load — route rather than leave a stale button.
+        if (reason === "no_creator") {
+          router.push(`/onboarding/handle?next=${encodeURIComponent(returnTo)}`);
+          return;
+        }
+        if (reason === "auth_required" || err.status === 401) {
+          setGateOpen(true);
+          return;
+        }
+        setError(err.userMessage);
+      } else {
+        setError("Something went wrong.");
+      }
+    } finally {
+      setPending(false);
+    }
+  }
+
+  const label = followState === "ready" && isFollowing ? "Following" : "Follow";
+  // "Following" reads as a quiet, already-done state; "Follow" is the primary
+  // pink CTA. Hover on "Following" hints the unfollow affordance.
+  const className =
+    followState === "ready" && isFollowing
+      ? "rounded-md border border-white/15 bg-white/5 px-4 py-1.5 text-body-sm font-semibold text-moonbeem-ink-muted transition-colors hover:border-moonbeem-magenta hover:text-moonbeem-magenta disabled:opacity-50"
+      : "rounded-md bg-moonbeem-pink px-4 py-1.5 text-body-sm font-semibold text-moonbeem-navy transition-opacity hover:opacity-90 disabled:opacity-50";
+
+  return (
+    <div className="flex shrink-0 flex-col items-center gap-1.5 sm:items-end">
+      <button
+        type="button"
+        onClick={() => void onClick()}
+        disabled={pending}
+        aria-pressed={followState === "ready" ? isFollowing : undefined}
+        className={className}
+      >
+        {label}
+      </button>
+      {/* Stat line — plain text now; Step 4/5 turns these into list links. */}
+      <p className={`m-0 ${FOLLOW_STAT_CLASS}`}>
+        {followStatText(count, followingCount)}
+      </p>
+      {error && (
+        <p className="m-0 text-body-sm text-moonbeem-magenta">{error}</p>
+      )}
+      {followState === "anon" && (
+        <GateModal
+          open={gateOpen}
+          onClose={() => setGateOpen(false)}
+          reason="auth_required"
+          returnTo={returnTo}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -7,6 +7,11 @@ import {
 } from "@/lib/socials/profile-url";
 import PlatformIcon from "@/components/PlatformIcon";
 import AvatarCircle from "./AvatarCircle";
+import FollowButton, {
+  FOLLOW_STAT_CLASS,
+  followStatText,
+} from "./FollowButton";
+import type { FollowState } from "@/lib/follows/server";
 import Top12Grid from "./Top12Grid";
 import ProfileFanEditCard from "./ProfileFanEditCard";
 import DiaryRow from "@/components/diary/DiaryRow";
@@ -28,6 +33,8 @@ type Props = {
   fanEdits: FanEditWithTitle[];
   watchedCount: number;
   isOwner: boolean;
+  followState: FollowState;
+  isFollowing: boolean;
 };
 
 export default function ProfileView({
@@ -39,6 +46,8 @@ export default function ProfileView({
   fanEdits,
   watchedCount,
   isOwner,
+  followState,
+  isFollowing,
 }: Props) {
   if (!profile) {
     return (
@@ -88,6 +97,28 @@ export default function ProfileView({
     </div>
   ) : null;
 
+  // Header-right slot: owner sees their controls + a STATIC follower/following
+  // byline (no button — own-profile hiding is decided here, server-side, by not
+  // rendering the FollowButton island at all). Everyone else gets the
+  // interactive FollowButton, which carries its own optimistic stat line.
+  const headerActions = isOwner ? (
+    <div className="flex shrink-0 flex-col items-center gap-1.5 sm:items-end">
+      {ownerControls}
+      <p className={`m-0 ${FOLLOW_STAT_CLASS}`}>
+        {followStatText(profile.follower_count, profile.following_count)}
+      </p>
+    </div>
+  ) : (
+    <FollowButton
+      targetCreatorId={profile.creator_id}
+      initialIsFollowing={isFollowing}
+      initialFollowerCount={profile.follower_count}
+      followingCount={profile.following_count}
+      followState={followState}
+      returnTo={`/c/${profile.handle}`}
+    />
+  );
+
   return (
     <div className="mx-auto flex w-full max-w-7xl flex-col gap-12 px-6 py-10">
       {/* HEADER (CF-4) — editorial identity block. Avatar left, identity
@@ -112,7 +143,7 @@ export default function ProfileView({
                 @{profile.handle}
               </p>
             </div>
-            {ownerControls}
+            {headerActions}
           </div>
 
           {/* Verified socials (elevated) → bio → watched → other links, on a

--- a/src/lib/follows/server.ts
+++ b/src/lib/follows/server.ts
@@ -1,0 +1,152 @@
+// Follow feature — Step 2: server layer (follow / unfollow / status).
+//
+// THE LOAD-BEARING RULE: the follower (actor) id ALWAYS comes from
+// resolveCreatorId(session user id), resolved server-side. It is NEVER taken
+// from client input. The target id is client-supplied. They are sourced
+// differently on purpose — if both came from the request body, that's the
+// forged-follow bug. The two are visually distinct below: `followerCreatorId`
+// is derived from `getUser()`, `target` is the function argument.
+//
+// WRITE PATH: both writes go through createServiceRoleClient(), with ownership
+// enforced here in app code via resolveCreatorId — identical to the seven
+// canonical owner-scoped tables (watched_titles, user_lists, ...) per
+// src/lib/lists/server.ts. The follows owner-write RLS policy is the
+// fail-closed backstop, not the happy path (Step 1 proved a direct
+// authenticated write fails 42501). Counters are maintained by the AFTER
+// INSERT/DELETE trigger — app code NEVER touches follower_count/following_count
+// directly.
+
+import { getUser } from "@/lib/dal";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import { resolveCreatorId } from "@/lib/lists/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// Structured result, never an exception. The client must distinguish three
+// outcomes: success, "no creator — go claim a handle" (a conversion prompt,
+// NOT a failure), and a genuine error. no_creator is deliberately NOT
+// collapsed into "error". auth_required is split out so an anon caller routes
+// to sign-in rather than onboarding.
+export type FollowOutcome =
+  | { ok: true; isFollowing: boolean; followerCount: number }
+  | { ok: false; reason: "auth_required" }
+  | { ok: false; reason: "no_creator" }
+  | { ok: false; reason: "self_follow" }
+  | { ok: false; reason: "target_not_found" }
+  | { ok: false; reason: "error" };
+
+async function readFollowerCount(
+  sb: SupabaseClient,
+  creatorId: string,
+): Promise<number> {
+  // Counts come from the denormalized column the trigger maintains — never
+  // count(*) on this path.
+  const { data } = await sb
+    .from("creators")
+    .select("follower_count")
+    .eq("id", creatorId)
+    .maybeSingle();
+  return (data?.follower_count as number | null) ?? 0;
+}
+
+export async function followCreator(
+  targetCreatorId: string,
+): Promise<FollowOutcome> {
+  const user = await getUser();
+  if (!user) return { ok: false, reason: "auth_required" };
+
+  // ACTOR — derived from the session, never from client input.
+  const followerCreatorId = await resolveCreatorId(user.id);
+  if (!followerCreatorId) return { ok: false, reason: "no_creator" };
+
+  // TARGET — client-supplied. Sourced differently from the actor by design.
+  const target = (targetCreatorId ?? "").trim();
+  if (!target) return { ok: false, reason: "target_not_found" };
+
+  // Self-follow guard (defense in depth — the CHECK constraint also blocks it).
+  if (followerCreatorId === target) return { ok: false, reason: "self_follow" };
+
+  const sb = createServiceRoleClient();
+
+  // Target must be a real, LIVE creator. The FK already guarantees existence;
+  // this additionally rejects soft-deleted creators (deleted_at IS NOT NULL).
+  const { data: targetRow, error: targetErr } = await sb
+    .from("creators")
+    .select("id")
+    .eq("id", target)
+    .is("deleted_at", null)
+    .maybeSingle();
+  if (targetErr) return { ok: false, reason: "error" };
+  if (!targetRow) return { ok: false, reason: "target_not_found" };
+
+  // Idempotent insert: ON CONFLICT DO NOTHING, so a double-tap is a no-op
+  // success rather than a 23505. The trigger increments the counters.
+  const { error: insErr } = await sb.from("follows").upsert(
+    { follower_creator_id: followerCreatorId, target_creator_id: target },
+    {
+      onConflict: "follower_creator_id,target_creator_id",
+      ignoreDuplicates: true,
+    },
+  );
+  if (insErr) return { ok: false, reason: "error" };
+
+  const followerCount = await readFollowerCount(sb, target);
+  return { ok: true, isFollowing: true, followerCount };
+}
+
+export async function unfollowCreator(
+  targetCreatorId: string,
+): Promise<FollowOutcome> {
+  const user = await getUser();
+  if (!user) return { ok: false, reason: "auth_required" };
+
+  // ACTOR — derived from the session, never from client input.
+  const followerCreatorId = await resolveCreatorId(user.id);
+  if (!followerCreatorId) return { ok: false, reason: "no_creator" };
+
+  // TARGET — client-supplied.
+  const target = (targetCreatorId ?? "").trim();
+  if (!target) return { ok: false, reason: "target_not_found" };
+
+  const sb = createServiceRoleClient();
+
+  // Idempotent delete: removing an edge that isn't there affects 0 rows and is
+  // a no-op success. The trigger decrements the counters (floored at 0).
+  const { error: delErr } = await sb
+    .from("follows")
+    .delete()
+    .eq("follower_creator_id", followerCreatorId)
+    .eq("target_creator_id", target);
+  if (delErr) return { ok: false, reason: "error" };
+
+  const followerCount = await readFollowerCount(sb, target);
+  return { ok: true, isFollowing: false, followerCount };
+}
+
+// Follow-status read for a (viewer, target) pair. The viewer is resolved from
+// the session user id (NEVER client input); an unclaimed or anon viewer simply
+// isn't following anyone, so this returns false rather than erroring.
+//
+// Designed to fold into the profile page's existing Promise.all (zero extra
+// round trip): call getFollowStatus(currentUser?.userId ?? null,
+// profile.creator_id) alongside the other parallel profile queries.
+//
+// `follows` has two FKs to `creators` (follower + target), which makes a
+// PostgREST embed ambiguous — so we reuse resolveCreatorId to get the viewer's
+// creator id, then do one unambiguous indexed PK probe on follows.
+export async function getFollowStatus(
+  viewerUserId: string | null,
+  targetCreatorId: string,
+): Promise<boolean> {
+  if (!viewerUserId || !targetCreatorId) return false;
+  const followerCreatorId = await resolveCreatorId(viewerUserId);
+  if (!followerCreatorId) return false;
+  if (followerCreatorId === targetCreatorId) return false; // can't follow self
+  const sb = createServiceRoleClient();
+  const { data } = await sb
+    .from("follows")
+    .select("target_creator_id")
+    .eq("follower_creator_id", followerCreatorId)
+    .eq("target_creator_id", targetCreatorId)
+    .limit(1);
+  return !!(data && data.length > 0);
+}

--- a/src/lib/follows/server.ts
+++ b/src/lib/follows/server.ts
@@ -150,3 +150,33 @@ export async function getFollowStatus(
     .limit(1);
   return !!(data && data.length > 0);
 }
+
+// What the Follow button needs to render, resolved server-side in ONE pass so
+// the button is correct on first paint and needs no round trip on click:
+//   "anon"       → viewer logged out (click → sign-in). Fires ZERO queries.
+//   "no_creator" → logged in but no claimed creator (click → /onboarding/handle).
+//                  Fires one resolveCreatorId (returns null); no follows probe.
+//   "ready"      → claimed creator; isFollowing reflects the live edge.
+// Built to drop into the profile page's existing Promise.all (no waterfall).
+export type FollowState = "anon" | "no_creator" | "ready";
+
+export async function getViewerFollowContext(
+  viewerUserId: string | null,
+  targetCreatorId: string,
+): Promise<{ followState: FollowState; isFollowing: boolean }> {
+  if (!viewerUserId) return { followState: "anon", isFollowing: false };
+  const followerCreatorId = await resolveCreatorId(viewerUserId);
+  if (!followerCreatorId) return { followState: "no_creator", isFollowing: false };
+  // Own creator — the page hides the button via isOwner; never self-following.
+  if (followerCreatorId === targetCreatorId) {
+    return { followState: "ready", isFollowing: false };
+  }
+  const sb = createServiceRoleClient();
+  const { data } = await sb
+    .from("follows")
+    .select("target_creator_id")
+    .eq("follower_creator_id", followerCreatorId)
+    .eq("target_creator_id", targetCreatorId)
+    .limit(1);
+  return { followState: "ready", isFollowing: !!(data && data.length > 0) };
+}

--- a/src/lib/queries/profiles.ts
+++ b/src/lib/queries/profiles.ts
@@ -26,6 +26,10 @@ export type Profile = {
   // and for users who toggled all of theirs off.
   verified_socials: VerifiedSocial[];
   is_stub: boolean;
+  // Denormalized follow counters (creators.follower_count / following_count,
+  // surfaced through public_creators). Trigger-maintained; never count(*).
+  follower_count: number;
+  following_count: number;
 };
 
 export type TopTitle = {
@@ -107,7 +111,9 @@ export async function getProfileByHandle(
 
   const { data: creator, error: cErr } = await supabase
     .from("public_creators")
-    .select("id, user_id, moonbeem_handle, is_stub")
+    .select(
+      "id, user_id, moonbeem_handle, is_stub, follower_count, following_count",
+    )
     .eq("moonbeem_handle", cleaned)
     .maybeSingle();
   if (cErr || !creator) return null;
@@ -116,6 +122,8 @@ export async function getProfileByHandle(
   const userId = (creator.user_id as string | null) ?? null;
   const moonbeemHandle = creator.moonbeem_handle as string;
   const isStub = Boolean(creator.is_stub);
+  const followerCount = (creator.follower_count as number | null) ?? 0;
+  const followingCount = (creator.following_count as number | null) ?? 0;
 
   if (!userId) {
     return {
@@ -128,6 +136,8 @@ export async function getProfileByHandle(
       links: [],
       verified_socials: [],
       is_stub: isStub,
+      follower_count: followerCount,
+      following_count: followingCount,
     };
   }
 
@@ -150,6 +160,8 @@ export async function getProfileByHandle(
     links: normalizeLinks(user?.links),
     verified_socials: verifiedSocials,
     is_stub: isStub,
+    follower_count: followerCount,
+    following_count: followingCount,
   };
 }
 

--- a/supabase/migrations/20260617000000_follows.sql
+++ b/supabase/migrations/20260617000000_follows.sql
@@ -1,0 +1,103 @@
+-- Follows — asymmetric creator-to-creator follow graph.
+--
+-- A follow is an edge (follower_creator_id -> target_creator_id). No
+-- request/accept state: following is one-directional and immediate. Both
+-- endpoints are creators.id; the target may be an unclaimed stub (you can
+-- follow a creator that has no user yet), the follower must be a claimed
+-- creator (the app resolves auth.uid() -> creators.id before any write).
+--
+-- NOT a money path: no apportionment, metering, or Stripe interaction.
+--
+-- RLS is the ENTIRE security story here. creators has wide-open base grants
+-- (anon + authenticated hold INSERT/UPDATE/DELETE) and only an INSERT policy,
+-- so we ship follows' complete policy set explicitly and never lean on an
+-- implicit SELECT policy. The counter trigger is SECURITY DEFINER precisely
+-- because creators has no UPDATE policy — an invoker-rights trigger would be
+-- silently blocked from maintaining the counts.
+
+-- ############################################################################
+-- 1. Table
+-- ############################################################################
+create table if not exists public.follows (
+  follower_creator_id uuid not null references public.creators(id) on delete cascade,
+  target_creator_id   uuid not null references public.creators(id) on delete cascade,
+  created_at          timestamptz not null default now(),
+  primary key (follower_creator_id, target_creator_id),
+  constraint follows_no_self_follow check (follower_creator_id <> target_creator_id)
+);
+
+-- PK (follower_creator_id, ...) already serves "who does X follow".
+-- This index serves the reverse: "who follows X".
+create index if not exists idx_follows_target on public.follows (target_creator_id);
+
+-- ############################################################################
+-- 2. RLS — public read, owner-only write through creators.user_id = auth.uid().
+--    Write policy mirrors the canonical seven-table pattern (watched_titles et
+--    al). The CHECK constraint blocks self-follow at the row level.
+-- ############################################################################
+alter table public.follows enable row level security;
+
+drop policy if exists "follows owner write" on public.follows;
+create policy "follows owner write"
+  on public.follows for all
+  using (exists (select 1 from public.creators c
+                 where c.id = follows.follower_creator_id and c.user_id = auth.uid()))
+  with check (exists (select 1 from public.creators c
+                 where c.id = follows.follower_creator_id and c.user_id = auth.uid()));
+
+drop policy if exists "follows public read" on public.follows;
+create policy "follows public read"
+  on public.follows for select
+  using (true);
+
+-- ############################################################################
+-- 3. Denormalized counters on creators (mirrors user_lists.item_count
+--    precedent — read on render, never count(*) on the hot path).
+-- ############################################################################
+alter table public.creators
+  add column if not exists follower_count  integer not null default 0,
+  add column if not exists following_count integer not null default 0;
+
+-- ############################################################################
+-- 4. Counter trigger. SECURITY DEFINER so the creators UPDATE is not blocked
+--    by RLS (creators has no UPDATE policy). search_path pinned to public.
+--    The follows base table is the ONLY write path, so this trigger is the
+--    single source of counter truth. DELETE guards against negative drift.
+-- ############################################################################
+create or replace function public.sync_follow_counts()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if tg_op = 'INSERT' then
+    update public.creators set following_count = following_count + 1
+      where id = new.follower_creator_id;
+    update public.creators set follower_count = follower_count + 1
+      where id = new.target_creator_id;
+    return new;
+  elsif tg_op = 'DELETE' then
+    update public.creators set following_count = greatest(following_count - 1, 0)
+      where id = old.follower_creator_id;
+    update public.creators set follower_count = greatest(follower_count - 1, 0)
+      where id = old.target_creator_id;
+    return old;
+  end if;
+  return null;
+end;
+$$;
+
+drop trigger if exists trg_sync_follow_counts on public.follows;
+create trigger trg_sync_follow_counts
+  after insert or delete on public.follows
+  for each row execute function public.sync_follow_counts();
+
+-- ############################################################################
+-- 5. Backfill / reconciliation. On a greenfield follows table this sets every
+--    creator to 0 (already the default). Kept as the canonical resync query:
+--    re-run this block to repair counters if they ever drift.
+-- ############################################################################
+update public.creators c set
+  following_count = (select count(*) from public.follows f where f.follower_creator_id = c.id),
+  follower_count  = (select count(*) from public.follows f where f.target_creator_id   = c.id);

--- a/supabase/migrations/20260617000001_public_creators_follow_counts.sql
+++ b/supabase/migrations/20260617000001_public_creators_follow_counts.sql
@@ -1,0 +1,19 @@
+-- Follow feature — Step 3: expose the denormalized follow counters through the
+-- public_creators view so the (anon-readable) profile fetch picks them up with
+-- no extra round trip. The view is owned by postgres and bypasses creators RLS,
+-- which is how anon already reads the profile shell — counts ride the same path.
+-- Counts are public (consistent with the open profile). CREATE OR REPLACE VIEW
+-- appends the two columns at the end and preserves existing grants.
+
+create or replace view public.public_creators as
+  select id,
+         user_id,
+         moonbeem_handle,
+         is_stub,
+         is_claimed,
+         profile_kind,
+         created_at,
+         follower_count,
+         following_count
+  from public.creators
+  where deleted_at is null;


### PR DESCRIPTION
**Draft — do not merge.** Staging for preview review of Step 3 (Follow button).

Steps 1–3 of the asymmetric creator-to-creator Follow feature.

- **Step 1** (`4d8eab2`): `follows` table, RLS (public read / fail-closed owner write), denormalized `follower_count`/`following_count` on `creators`, SECURITY DEFINER counter trigger. Applied + verified live on `qdngcwhubzomwymhaiel`.
- **Step 2** (`2d96c8c`): `followCreator` / `unfollowCreator` / `getFollowStatus` — self-resolving actor (never client input), service-role writes, structured `FollowOutcome`.
- **Step 3** (`a872734`): `/api/follows` route (rate-limited `userWrites` 30/min/user, passes only the target), `FollowButton` client island (5 states, optimistic, server-hidden on own profile), follower/following counts on `/c/[handle]` via the `public_creators` view.

### Preview review checklist (the three states to click)
- [ ] **Anon** (logged out): "Follow" → opens sign-in gate
- [ ] **Claimed creator** on someone else's profile: Follow ↔ Following, count adjusts optimistically
- [ ] **Own profile**: no Follow button (counts byline only)
- [ ] (bonus) **Signed-in but no claimed handle**: "Follow" → routes to /onboarding/handle

Out of scope (Steps 4/5): follower/following list views, feed, notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)