### PR TITLE
fix(profile): owner self-view RSC boundary on /c/[handle]

### DIFF
--- a/src/components/profile/FollowButton.tsx
+++ b/src/components/profile/FollowButton.tsx
@@ -25,15 +25,7 @@ import { useRouter } from "next/navigation";
 import GateModal from "@/components/gating/GateModal";
 import { fetchJson, FetchJsonError } from "@/lib/fetch-json";
 import type { FollowState } from "@/lib/follows/server";
-
-// Shared so the static owner byline (ProfileView) is byte-identical.
-export const FOLLOW_STAT_CLASS = "text-caption text-moonbeem-ink-subtle";
-
-export function followStatText(followers: number, following: number): string {
-  return `${followers.toLocaleString()} ${
-    followers === 1 ? "follower" : "followers"
-  } · ${following.toLocaleString()} following`;
-}
+import { FOLLOW_STAT_CLASS, followStatText } from "./follow-stat";
 
 type FollowResponse = {
   ok: boolean;

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -7,10 +7,8 @@ import {
 } from "@/lib/socials/profile-url";
 import PlatformIcon from "@/components/PlatformIcon";
 import AvatarCircle from "./AvatarCircle";
-import FollowButton, {
-  FOLLOW_STAT_CLASS,
-  followStatText,
-} from "./FollowButton";
+import FollowButton from "./FollowButton";
+import { FOLLOW_STAT_CLASS, followStatText } from "./follow-stat";
 import type { FollowState } from "@/lib/follows/server";
 import Top12Grid from "./Top12Grid";
 import ProfileFanEditCard from "./ProfileFanEditCard";

--- a/src/components/profile/follow-stat.ts
+++ b/src/components/profile/follow-stat.ts
@@ -1,0 +1,15 @@
+// Neutral (no "use client" / "use server") helpers for the follower/following
+// stat byline. Importable from BOTH the Server Component (ProfileView's owner
+// byline) and the Client island (FollowButton's optimistic byline) so the two
+// render byte-identically from one source. Extracted out of FollowButton.tsx
+// (a "use client" module) because a Server Component calling a client-module
+// export crosses the RSC boundary and throws — that was the owner self-view bug.
+
+// Shared so the static owner byline (ProfileView) is byte-identical.
+export const FOLLOW_STAT_CLASS = "text-caption text-moonbeem-ink-subtle";
+
+export function followStatText(followers: number, following: number): string {
+  return `${followers.toLocaleString()} ${
+    followers === 1 ? "follower" : "followers"
+  } · ${following.toLocaleString()} following`;
+}


### PR DESCRIPTION
**Draft — do not merge.** Hotfix for the owner self-view crash.

**Root cause:** `ProfileView` (Server Component) called `followStatText()` / used `FOLLOW_STAT_CLASS` in the `isOwner` branch; both were exports of `FollowButton.tsx` (`"use client"`). Calling a client-module function from server render crosses the RSC boundary → throws → `error.tsx` ("Couldn't load that creator."). Only signed-in owner self-views were affected; visitor/non-owner views were fine.

**Fix (Option 1):** move `followStatText` + `FOLLOW_STAT_CLASS` verbatim into a new directive-free module `src/components/profile/follow-stat.ts`; both `ProfileView` (server) and `FollowButton` (client) import from there. Single source of truth; bylines stay byte-identical.

Render-layer only — no DB change, no migration, follows table/view untouched. tsc + next build clean.

### Preview check
- [ ] anon `/c/laurenguido` still renders (non-owner regression check)
- [ ] (Dan, post-merge on prod) own profile `/c/dansickles` signed in renders the byline, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)