### PR TITLE
follows: public follower/following list views (Step 4/5)

### DIFF
--- a/src/app/c/[handle]/followers/page.tsx
+++ b/src/app/c/[handle]/followers/page.tsx
@@ -1,0 +1,104 @@
+// Step 4/5 — public followers list. Mirrors the watched sub-page anatomy:
+// resolve the handle to a creator (anon SSR), notFound() a missing/stub/
+// unclaimed SUBJECT (same condition the /c/[handle] profile page uses to decide
+// a handle is a real profile — note that page renders an "unclaimed" message
+// rather than 404, but the follower byline that links here only exists on
+// claimed profiles, so 404 is the honest behavior for a direct hit on a stub).
+// The ROWS, however, may be stubs — the read does NOT filter on is_stub.
+//
+// Header count comes from the denormalized profile.follower_count (NEVER
+// count(*)). Pagination: offset/limit page size 30, ?page=, prev/next.
+
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { getProfileByHandle } from "@/lib/queries/profiles";
+import { getFollowersOfCreator } from "@/lib/follows/server";
+import CreatorRow from "@/components/profile/CreatorRow";
+
+const PAGE_SIZE = 30;
+
+export default async function FollowersPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ handle: string }>;
+  searchParams: Promise<{ page?: string }>;
+}) {
+  const { handle } = await params;
+  const { page: pageParam } = await searchParams;
+  const profile = await getProfileByHandle(handle);
+  if (!profile || profile.is_stub || !profile.user_id) notFound();
+
+  const page = Math.max(1, Number.parseInt(pageParam ?? "1", 10) || 1);
+  const offset = (page - 1) * PAGE_SIZE;
+  const rows = await getFollowersOfCreator(profile.creator_id, {
+    limit: PAGE_SIZE,
+    offset,
+  });
+
+  // Denormalized count for the header — never count(*).
+  const total = profile.follower_count;
+  const hasPrev = page > 1;
+  // A full page implies there may be more — avoids a count query.
+  const hasNext = rows.length === PAGE_SIZE;
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-8 px-6 py-10">
+      <div className="flex flex-col gap-2">
+        <Link
+          href={`/c/${profile.handle}`}
+          prefetch={false}
+          className="text-body-sm text-moonbeem-ink-subtle transition-colors hover:text-moonbeem-pink"
+        >
+          ← {profile.display_name ?? `@${profile.handle}`}
+        </Link>
+        <h1 className="m-0 font-wordmark text-heading-lg text-moonbeem-ink">
+          Followers
+        </h1>
+        <p className="m-0 text-body-sm text-moonbeem-ink-subtle">
+          {total.toLocaleString()} {total === 1 ? "follower" : "followers"} · @
+          {profile.handle}
+        </p>
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="text-body-sm text-moonbeem-ink-subtle">
+          No followers yet.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {rows.map((c) => (
+            <CreatorRow key={c.creatorId} creator={c} />
+          ))}
+        </div>
+      )}
+
+      {(hasPrev || hasNext) && (
+        <div className="flex items-center justify-between border-t border-white/10 pt-4">
+          {hasPrev ? (
+            <Link
+              href={`/c/${profile.handle}/followers?page=${page - 1}`}
+              prefetch={false}
+              className="text-body-sm text-moonbeem-ink-subtle transition-colors hover:text-moonbeem-pink"
+            >
+              ← Previous
+            </Link>
+          ) : (
+            <span />
+          )}
+          {hasNext ? (
+            <Link
+              href={`/c/${profile.handle}/followers?page=${page + 1}`}
+              prefetch={false}
+              className="text-body-sm text-moonbeem-ink-subtle transition-colors hover:text-moonbeem-pink"
+            >
+              Next →
+            </Link>
+          ) : (
+            <span />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/c/[handle]/followers/page.tsx
+++ b/src/app/c/[handle]/followers/page.tsx
@@ -27,7 +27,13 @@ export default async function FollowersPage({
   const { handle } = await params;
   const { page: pageParam } = await searchParams;
   const profile = await getProfileByHandle(handle);
-  if (!profile || profile.is_stub || !profile.user_id) notFound();
+  // Only a genuinely missing/deleted handle 404s (getProfileByHandle returns
+  // null when no live creator row matches). A STUB/unclaimed subject renders
+  // 200 WITH the list — a stub seeing their waiting followers is the claim
+  // incentive. Parity with /c/[handle], which shows the unclaimed framing for a
+  // stub. The rows are NEVER gated behind the unclaimed state.
+  if (!profile) notFound();
+  const isUnclaimed = profile.is_stub || !profile.user_id;
 
   const page = Math.max(1, Number.parseInt(pageParam ?? "1", 10) || 1);
   const offset = (page - 1) * PAGE_SIZE;
@@ -60,6 +66,26 @@ export default async function FollowersPage({
           {profile.handle}
         </p>
       </div>
+
+      {/* Unclaimed framing — mirrors the /c/[handle] stub copy (ProfileView's
+          null branch), but ADDITIVE: the follower rows still render beneath it.
+          A stub with followers seeing them is the claim incentive. */}
+      {isUnclaimed && (
+        <div className="rounded-lg border border-moonbeem-pink/30 bg-moonbeem-pink/10 p-4">
+          <p className="m-0 text-body text-moonbeem-ink-muted">
+            This handle isn&apos;t claimed yet.
+          </p>
+          <p className="m-0 mt-1 text-body-sm text-moonbeem-ink-subtle">
+            If you&apos;re @{profile.handle}, sign up to claim it.
+          </p>
+          <Link
+            href="/login"
+            className="mt-4 inline-block rounded-md bg-moonbeem-pink px-4 py-2 text-body-sm font-semibold text-moonbeem-navy transition-opacity hover:opacity-90"
+          >
+            Sign up
+          </Link>
+        </div>
+      )}
 
       {rows.length === 0 ? (
         <p className="text-body-sm text-moonbeem-ink-subtle">

--- a/src/app/c/[handle]/following/page.tsx
+++ b/src/app/c/[handle]/following/page.tsx
@@ -21,7 +21,11 @@ export default async function FollowingPage({
   const { handle } = await params;
   const { page: pageParam } = await searchParams;
   const profile = await getProfileByHandle(handle);
-  if (!profile || profile.is_stub || !profile.user_id) notFound();
+  // Only a genuinely missing/deleted handle 404s. A STUB/unclaimed subject
+  // renders 200 WITH the list (parity with /c/[handle]); rows are never gated
+  // behind the unclaimed state.
+  if (!profile) notFound();
+  const isUnclaimed = profile.is_stub || !profile.user_id;
 
   const page = Math.max(1, Number.parseInt(pageParam ?? "1", 10) || 1);
   const offset = (page - 1) * PAGE_SIZE;
@@ -51,6 +55,25 @@ export default async function FollowingPage({
           {total.toLocaleString()} following · @{profile.handle}
         </p>
       </div>
+
+      {/* Unclaimed framing — mirrors the /c/[handle] stub copy, additive: the
+          following rows still render beneath it. */}
+      {isUnclaimed && (
+        <div className="rounded-lg border border-moonbeem-pink/30 bg-moonbeem-pink/10 p-4">
+          <p className="m-0 text-body text-moonbeem-ink-muted">
+            This handle isn&apos;t claimed yet.
+          </p>
+          <p className="m-0 mt-1 text-body-sm text-moonbeem-ink-subtle">
+            If you&apos;re @{profile.handle}, sign up to claim it.
+          </p>
+          <Link
+            href="/login"
+            className="mt-4 inline-block rounded-md bg-moonbeem-pink px-4 py-2 text-body-sm font-semibold text-moonbeem-navy transition-opacity hover:opacity-90"
+          >
+            Sign up
+          </Link>
+        </div>
+      )}
 
       {rows.length === 0 ? (
         <p className="text-body-sm text-moonbeem-ink-subtle">

--- a/src/app/c/[handle]/following/page.tsx
+++ b/src/app/c/[handle]/following/page.tsx
@@ -1,0 +1,95 @@
+// Step 4/5 — public following list. Sibling of followers/page.tsx; same anatomy,
+// reads getFollowingOfCreator (who X follows). notFound() a missing/stub/
+// unclaimed SUBJECT; ROWS may be stubs (read does NOT filter is_stub). Header
+// count from the denormalized profile.following_count (never count(*)).
+
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { getProfileByHandle } from "@/lib/queries/profiles";
+import { getFollowingOfCreator } from "@/lib/follows/server";
+import CreatorRow from "@/components/profile/CreatorRow";
+
+const PAGE_SIZE = 30;
+
+export default async function FollowingPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ handle: string }>;
+  searchParams: Promise<{ page?: string }>;
+}) {
+  const { handle } = await params;
+  const { page: pageParam } = await searchParams;
+  const profile = await getProfileByHandle(handle);
+  if (!profile || profile.is_stub || !profile.user_id) notFound();
+
+  const page = Math.max(1, Number.parseInt(pageParam ?? "1", 10) || 1);
+  const offset = (page - 1) * PAGE_SIZE;
+  const rows = await getFollowingOfCreator(profile.creator_id, {
+    limit: PAGE_SIZE,
+    offset,
+  });
+
+  const total = profile.following_count;
+  const hasPrev = page > 1;
+  const hasNext = rows.length === PAGE_SIZE;
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-8 px-6 py-10">
+      <div className="flex flex-col gap-2">
+        <Link
+          href={`/c/${profile.handle}`}
+          prefetch={false}
+          className="text-body-sm text-moonbeem-ink-subtle transition-colors hover:text-moonbeem-pink"
+        >
+          ← {profile.display_name ?? `@${profile.handle}`}
+        </Link>
+        <h1 className="m-0 font-wordmark text-heading-lg text-moonbeem-ink">
+          Following
+        </h1>
+        <p className="m-0 text-body-sm text-moonbeem-ink-subtle">
+          {total.toLocaleString()} following · @{profile.handle}
+        </p>
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="text-body-sm text-moonbeem-ink-subtle">
+          Not following anyone yet.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {rows.map((c) => (
+            <CreatorRow key={c.creatorId} creator={c} />
+          ))}
+        </div>
+      )}
+
+      {(hasPrev || hasNext) && (
+        <div className="flex items-center justify-between border-t border-white/10 pt-4">
+          {hasPrev ? (
+            <Link
+              href={`/c/${profile.handle}/following?page=${page - 1}`}
+              prefetch={false}
+              className="text-body-sm text-moonbeem-ink-subtle transition-colors hover:text-moonbeem-pink"
+            >
+              ← Previous
+            </Link>
+          ) : (
+            <span />
+          )}
+          {hasNext ? (
+            <Link
+              href={`/c/${profile.handle}/following?page=${page + 1}`}
+              prefetch={false}
+              className="text-body-sm text-moonbeem-ink-subtle transition-colors hover:text-moonbeem-pink"
+            >
+              Next →
+            </Link>
+          ) : (
+            <span />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/CreatorRow.tsx
+++ b/src/components/profile/CreatorRow.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import AvatarCircle from "./AvatarCircle";
+import type { CreatorRow as CreatorRowData } from "@/lib/follows/server";
+
+// A single navigational row in a follower / following list. Plain server
+// component (no client island — these lists are high-density link surfaces, so
+// every row is just a Link). prefetch={false} is REQUIRED here: a follower list
+// is exactly the surface the 58-fan-edit prefetch storm came from, and prefetch
+// is not inherited — it must be set explicitly on every creator link.
+//
+// Stub rows (no linked user) arrive with displayName/avatarUrl null: the name
+// falls back to the handle and AvatarCircle renders initials. They are normal,
+// un-badged rows by design.
+export default function CreatorRow({ creator }: { creator: CreatorRowData }) {
+  const name = creator.displayName ?? creator.handle;
+  return (
+    <Link
+      href={`/c/${creator.handle}`}
+      prefetch={false}
+      className="flex items-center gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-white/5"
+    >
+      <AvatarCircle
+        avatarUrl={creator.avatarUrl}
+        displayName={creator.displayName}
+        handle={creator.handle}
+        size={44}
+        className="shrink-0"
+      />
+      <div className="min-w-0">
+        <p className="m-0 truncate text-body-sm font-medium text-moonbeem-ink">
+          {name}
+        </p>
+        <p className="m-0 truncate text-caption text-moonbeem-ink-subtle">
+          @{creator.handle}
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/profile/FollowButton.tsx
+++ b/src/components/profile/FollowButton.tsx
@@ -25,7 +25,7 @@ import { useRouter } from "next/navigation";
 import GateModal from "@/components/gating/GateModal";
 import { fetchJson, FetchJsonError } from "@/lib/fetch-json";
 import type { FollowState } from "@/lib/follows/server";
-import { FOLLOW_STAT_CLASS, followStatText } from "./follow-stat";
+import FollowStatLinks from "./FollowStatLinks";
 
 type FollowResponse = {
   ok: boolean;
@@ -36,6 +36,7 @@ type FollowResponse = {
 
 export default function FollowButton({
   targetCreatorId,
+  handle,
   initialIsFollowing,
   initialFollowerCount,
   followingCount,
@@ -43,6 +44,7 @@ export default function FollowButton({
   returnTo,
 }: {
   targetCreatorId: string;
+  handle: string;
   initialIsFollowing: boolean;
   initialFollowerCount: number;
   followingCount: number;
@@ -133,10 +135,13 @@ export default function FollowButton({
       >
         {label}
       </button>
-      {/* Stat line — plain text now; Step 4/5 turns these into list links. */}
-      <p className={`m-0 ${FOLLOW_STAT_CLASS}`}>
-        {followStatText(count, followingCount)}
-      </p>
+      {/* Stat line — linkified. `count` is the LIVE optimistic follower count,
+          so the byline updates on follow/unfollow without a refresh. */}
+      <FollowStatLinks
+        followers={count}
+        following={followingCount}
+        handle={handle}
+      />
       {error && (
         <p className="m-0 text-body-sm text-moonbeem-magenta">{error}</p>
       )}

--- a/src/components/profile/FollowStatLinks.tsx
+++ b/src/components/profile/FollowStatLinks.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { FOLLOW_STAT_CLASS } from "./follow-stat";
+
+// Linkified follower/following byline. DIRECTIVE-FREE module (no "use client" /
+// "use server") so it can be RENDERED by both the Server Component (ProfileView
+// owner byline) and the Client island (FollowButton) — the same single-source
+// shape the RSC hotfix established. The earlier bug was CALLING a client-module
+// function from the server; rendering a neutral component across the boundary is
+// legal. A pure render — counts + handle come in as props, so FollowButton can
+// feed its LIVE optimistic count and the byline updates without a refresh.
+//
+// prefetch={false} on both links: these point at the high-density follower /
+// following lists and must not prefetch. Text format (toLocaleString, singular/
+// plural, " · " separator) is identical to the old followStatText string, just
+// split into two clickable segments.
+export default function FollowStatLinks({
+  followers,
+  following,
+  handle,
+}: {
+  followers: number;
+  following: number;
+  handle: string;
+}) {
+  return (
+    <p className={`m-0 ${FOLLOW_STAT_CLASS}`}>
+      <Link
+        href={`/c/${handle}/followers`}
+        prefetch={false}
+        className="transition-colors hover:text-moonbeem-pink hover:underline"
+      >
+        {followers.toLocaleString()} {followers === 1 ? "follower" : "followers"}
+      </Link>
+      {" · "}
+      <Link
+        href={`/c/${handle}/following`}
+        prefetch={false}
+        className="transition-colors hover:text-moonbeem-pink hover:underline"
+      >
+        {following.toLocaleString()} following
+      </Link>
+    </p>
+  );
+}

--- a/src/components/profile/ProfileView.tsx
+++ b/src/components/profile/ProfileView.tsx
@@ -8,7 +8,7 @@ import {
 import PlatformIcon from "@/components/PlatformIcon";
 import AvatarCircle from "./AvatarCircle";
 import FollowButton from "./FollowButton";
-import { FOLLOW_STAT_CLASS, followStatText } from "./follow-stat";
+import FollowStatLinks from "./FollowStatLinks";
 import type { FollowState } from "@/lib/follows/server";
 import Top12Grid from "./Top12Grid";
 import ProfileFanEditCard from "./ProfileFanEditCard";
@@ -102,13 +102,16 @@ export default function ProfileView({
   const headerActions = isOwner ? (
     <div className="flex shrink-0 flex-col items-center gap-1.5 sm:items-end">
       {ownerControls}
-      <p className={`m-0 ${FOLLOW_STAT_CLASS}`}>
-        {followStatText(profile.follower_count, profile.following_count)}
-      </p>
+      <FollowStatLinks
+        followers={profile.follower_count}
+        following={profile.following_count}
+        handle={profile.handle}
+      />
     </div>
   ) : (
     <FollowButton
       targetCreatorId={profile.creator_id}
+      handle={profile.handle}
       initialIsFollowing={isFollowing}
       initialFollowerCount={profile.follower_count}
       followingCount={profile.following_count}

--- a/src/lib/follows/server.ts
+++ b/src/lib/follows/server.ts
@@ -17,6 +17,7 @@
 // directly.
 
 import { getUser } from "@/lib/dal";
+import { createClient } from "@/lib/supabase/server";
 import { createServiceRoleClient } from "@/lib/supabase/service";
 import { resolveCreatorId } from "@/lib/lists/server";
 import type { SupabaseClient } from "@supabase/supabase-js";
@@ -179,4 +180,132 @@ export async function getViewerFollowContext(
     .eq("target_creator_id", targetCreatorId)
     .limit(1);
   return { followState: "ready", isFollowing: !!(data && data.length > 0) };
+}
+
+// ============================================================================
+// Step 4/5: public follower / following list reads.
+//
+// PUBLIC reads via the anon SSR client (createClient), matching
+// getProfileByHandle. follows is public-read RLS; public_creators and
+// public_profiles are anon-readable. No service-role needed.
+//
+// `follows` has two FKs to creators, so a PostgREST embed is ambiguous — we do
+// a batched MULTI-STEP read (no embed): (1) page the follows edge ids ordered
+// newest-first, (2) .in() public_creators for handle/user_id/is_stub (the view
+// carries no name/avatar), (3) .in() public_profiles for name/avatar by the
+// non-null user_ids. Stubs (user_id NULL) have no public_profiles row → null
+// name/avatar; they are NOT dropped (AvatarCircle renders initials).
+//
+// THE ORDERING GOTCHA: the .in() reads return rows in arbitrary order. The
+// stitch iterates the step-1 ORDERED id list and looks each up in keyed maps,
+// so the created_at-desc order survives. A naive map over the .in() results
+// would lose it.
+// ============================================================================
+export type CreatorRow = {
+  creatorId: string;
+  handle: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  isStub: boolean;
+};
+
+// Resolve an ORDERED list of creator ids into display rows, preserving order.
+async function hydrateCreatorRows(
+  supabase: SupabaseClient,
+  orderedIds: string[],
+): Promise<CreatorRow[]> {
+  if (orderedIds.length === 0) return [];
+
+  // Step 2 — handle / user_id / is_stub from the anon-readable view.
+  const { data: creators } = await supabase
+    .from("public_creators")
+    .select("id, moonbeem_handle, user_id, is_stub")
+    .in("id", orderedIds);
+  const byId = new Map<
+    string,
+    { handle: string; userId: string | null; isStub: boolean }
+  >();
+  for (const c of creators ?? []) {
+    byId.set(c.id as string, {
+      handle: c.moonbeem_handle as string,
+      userId: (c.user_id as string | null) ?? null,
+      isStub: Boolean(c.is_stub),
+    });
+  }
+
+  // Step 3 — name / avatar from public_profiles, keyed by user_id (claimed
+  // creators only; stubs have no user and stay null).
+  const userIds = Array.from(
+    new Set(
+      Array.from(byId.values())
+        .map((c) => c.userId)
+        .filter((u): u is string => !!u),
+    ),
+  );
+  const profileByUserId = new Map<
+    string,
+    { displayName: string | null; avatarUrl: string | null }
+  >();
+  if (userIds.length > 0) {
+    const { data: profiles } = await supabase
+      .from("public_profiles")
+      .select("id, display_name, avatar_url")
+      .in("id", userIds);
+    for (const p of profiles ?? []) {
+      profileByUserId.set(p.id as string, {
+        displayName: (p.display_name as string | null) ?? null,
+        avatarUrl: (p.avatar_url as string | null) ?? null,
+      });
+    }
+  }
+
+  // Step 4 — stitch in the ORIGINAL ordered-id order (NOT the .in() order).
+  const rows: CreatorRow[] = [];
+  for (const id of orderedIds) {
+    const c = byId.get(id);
+    if (!c) continue; // creator soft-deleted / not in the view → drop silently
+    const prof = c.userId ? profileByUserId.get(c.userId) : undefined;
+    rows.push({
+      creatorId: id,
+      handle: c.handle,
+      displayName: prof?.displayName ?? null,
+      avatarUrl: prof?.avatarUrl ?? null,
+      isStub: c.isStub,
+    });
+  }
+  return rows;
+}
+
+// Followers of X: rows where target_creator_id = X, the FOLLOWER hydrated.
+// Newest-follow-first. Served by idx_follows_target.
+export async function getFollowersOfCreator(
+  creatorId: string,
+  { limit, offset }: { limit: number; offset: number },
+): Promise<CreatorRow[]> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("follows")
+    .select("follower_creator_id, created_at")
+    .eq("target_creator_id", creatorId)
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+  const orderedIds = (data ?? []).map((r) => r.follower_creator_id as string);
+  return hydrateCreatorRows(supabase, orderedIds);
+}
+
+// Who X follows: rows where follower_creator_id = X, the TARGET hydrated.
+// Newest-follow-first. Served by the follows PK prefix.
+export async function getFollowingOfCreator(
+  creatorId: string,
+  { limit, offset }: { limit: number; offset: number },
+): Promise<CreatorRow[]> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("follows")
+    .select("target_creator_id, created_at")
+    .eq("follower_creator_id", creatorId)
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+  const orderedIds = (data ?? []).map((r) => r.target_creator_id as string);
+  return hydrateCreatorRows(supabase, orderedIds);
 }


### PR DESCRIPTION
**Draft — do not merge.** Staging for authenticated preview review.

Step 4/5 of the Follow feature: the two public list pages the `/c/[handle]` counts link to.

- **Reads** (`follows/server.ts`): `getFollowersOfCreator` / `getFollowingOfCreator` — anon SSR client, batched multi-step (no embed; two FKs to creators), newest-first, offset/limit. **Order-preserving stitch** verified live (the `.in()` reads return arbitrary order; the function reorders by the step-1 ids). Stubs are normal rows, never filtered.
- **CreatorRow**: AvatarCircle + name + `@handle`, single `Link prefetch={false}`.
- **Routes**: `/c/[handle]/followers` + `/following` — anon, `notFound()` on stub/unclaimed subject, header count from the denormalized column, page 30, `?page=`, prev/next.
- **Part D**: `FollowStatLinks` (directive-free component, rendered by both server `ProfileView` and client `FollowButton`) linkifies the counts; FollowButton feeds its live optimistic count so the byline still updates without a refresh.

Data layer verified live (seed → verify → cleanup, baseline restored): order, stub null-fields, claimed populated incl. avatar, pagination slices, anon read. tsc + next build clean. No migration.

### Preview checklist
- [ ] my own followers / following lists render
- [ ] a list containing a stub row (initials avatar + handle, links to /c/[handle])
- [ ] the linkified counts on /c/[handle] navigate to the right lists
- [ ] empty states ("No followers yet." / "Not following anyone yet.")
- [ ] **REGRESSION**: signed-in /c/dansickles still renders the byline (no "Couldn't load that creator")

🤖 Generated with [Claude Code](https://claude.com/claude-code)