### PR TITLE
title: poster_url editor (super-admin OR owning-partner-admin)

### DIFF
--- a/src/app/admin/titles/[slug]/TitleDetailTabs.tsx
+++ b/src/app/admin/titles/[slug]/TitleDetailTabs.tsx
@@ -113,6 +113,7 @@ type Props = {
   partnerName: string | null;
   partnerSlug: string | null;
   hasPartner: boolean;
+  posterUrl: string | null;
   allPartners: PartnerOption[];
   fanEdits: FanEditRow[];
   clips: ClipRow[];
@@ -305,8 +306,10 @@ export default function TitleDetailTabs(props: Props) {
           )}
           {tab === "settings" && (
             <SettingsTab
+              titleId={props.titleId}
               slug={props.titleSlug}
               titleName={props.titleName}
+              initialPosterUrl={props.posterUrl}
               initialIsActive={props.isActive}
               initialIsPublic={props.isPublic}
               initialPartnerId={props.partnerId}
@@ -1003,11 +1006,143 @@ function UploadTab({
   );
 }
 
+function isValidHttpUrl(s: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(s);
+  } catch {
+    return false;
+  }
+  return u.protocol === "http:" || u.protocol === "https:";
+}
+
+// Poster URL editor — URL only (file upload to R2 is a deferred follow-on).
+// Shows the CURRENT poster so a broken/fragile one is visibly broken, a
+// prefilled URL input, and a Save that PATCHes /api/titles/[id]/poster (the
+// super-admin-OR-owning-partner gate). poster_url is the single column every
+// display surface reads (title page + cards).
+function PosterEditor({
+  titleId,
+  titleSlug,
+  initialPosterUrl,
+}: {
+  titleId: string;
+  titleSlug: string;
+  initialPosterUrl: string | null;
+}) {
+  const [saved, setSaved] = useState<string | null>(initialPosterUrl);
+  const [value, setValue] = useState(initialPosterUrl ?? "");
+  const [state, setState] = useState<"idle" | "saving" | "error" | "saved">(
+    "idle",
+  );
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [imgFailed, setImgFailed] = useState(false);
+
+  const trimmed = value.trim();
+  const dirty = trimmed !== (saved ?? "");
+  const malformed = trimmed.length > 0 && !isValidHttpUrl(trimmed);
+  const canSave = dirty && isValidHttpUrl(trimmed) && state !== "saving";
+
+  async function save() {
+    if (!canSave) return;
+    setState("saving");
+    setErrorMsg(null);
+    try {
+      const res = await fetch(`/api/titles/${titleId}/poster`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ poster_url: trimmed }),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        poster_url?: string;
+        error?: string;
+      };
+      if (!res.ok || !json.ok || !json.poster_url) {
+        setState("error");
+        setErrorMsg(json.error ?? `request failed (${res.status})`);
+        return;
+      }
+      setSaved(json.poster_url);
+      setValue(json.poster_url);
+      setImgFailed(false);
+      setState("saved");
+    } catch (err) {
+      setState("error");
+      setErrorMsg(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+      <h2 className="m-0 text-body font-medium text-moonbeem-ink">Poster</h2>
+      <p className="mt-1 text-caption text-moonbeem-ink-subtle">
+        The image shown on <code className="font-mono">/t/{titleSlug}</code> and
+        on cards across the site. URL only — paste a durable image link.
+      </p>
+
+      <div className="mt-5 flex flex-col gap-4 sm:flex-row sm:items-start">
+        <div className="relative aspect-[2/3] w-[120px] shrink-0 overflow-hidden rounded-lg border border-white/10 bg-moonbeem-navy/40">
+          {saved && !imgFailed ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={saved}
+              alt="Current poster"
+              className="h-full w-full object-cover"
+              onError={() => setImgFailed(true)}
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center p-2 text-center text-caption text-moonbeem-ink-subtle">
+              {saved ? "⚠ failed to load" : "no poster"}
+            </div>
+          )}
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <input
+            type="url"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+              if (state !== "idle") setState("idle");
+            }}
+            placeholder="https://…"
+            className="w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-body-sm text-moonbeem-ink focus:border-moonbeem-pink focus:outline-none"
+          />
+          {malformed && (
+            <p className="m-0 text-caption text-moonbeem-magenta">
+              Enter a valid http(s) URL.
+            </p>
+          )}
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={save}
+              disabled={!canSave}
+              className="rounded-md bg-moonbeem-pink px-4 py-2 text-body-sm font-semibold text-moonbeem-navy transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {state === "saving" ? "Saving…" : "Save poster"}
+            </button>
+            {state === "saved" && !dirty && (
+              <span className="text-caption text-emerald-300">Saved ✓</span>
+            )}
+          </div>
+          {errorMsg && (
+            <p className="m-0 text-caption text-moonbeem-magenta">{errorMsg}</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 type SettingsState = "idle" | "saving" | "error";
 
 function SettingsTab({
+  titleId,
   slug,
   titleName,
+  initialPosterUrl,
   initialIsActive,
   initialIsPublic,
   initialPartnerId,
@@ -1015,8 +1150,10 @@ function SettingsTab({
   initialPartnerSlug,
   allPartners,
 }: {
+  titleId: string;
   slug: string;
   titleName: string;
+  initialPosterUrl: string | null;
   initialIsActive: boolean;
   initialIsPublic: boolean;
   initialPartnerId: string | null;
@@ -1150,6 +1287,12 @@ function SettingsTab({
 
   return (
     <div className="flex flex-col gap-6">
+      <PosterEditor
+        titleId={titleId}
+        titleSlug={slug}
+        initialPosterUrl={initialPosterUrl}
+      />
+
       <section className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
         <h2 className="m-0 text-body font-medium text-moonbeem-ink">
           Status

--- a/src/app/admin/titles/[slug]/page.tsx
+++ b/src/app/admin/titles/[slug]/page.tsx
@@ -78,7 +78,7 @@ export default async function AdminTitleDetailPage({
   const { data: title, error: titleErr } = await supabase
     .from("titles")
     .select(
-      "id, slug, title, is_active, is_public, partner_id, deleted_at, partners:partner_id(name, slug)",
+      "id, slug, title, is_active, is_public, partner_id, poster_url, deleted_at, partners:partner_id(name, slug)",
     )
     .eq("slug", slug)
     .maybeSingle();
@@ -94,6 +94,7 @@ export default async function AdminTitleDetailPage({
     is_active: boolean;
     is_public: boolean;
     partner_id: string | null;
+    poster_url: string | null;
     deleted_at: string | null;
     partners: { name: string; slug: string } | null;
   };
@@ -247,6 +248,7 @@ export default async function AdminTitleDetailPage({
       partnerName={t.partners?.name ?? null}
       partnerSlug={t.partners?.slug ?? null}
       hasPartner={!!t.partner_id}
+      posterUrl={t.poster_url}
       allPartners={allPartners}
       fanEdits={fanEdits}
       clips={clips}

--- a/src/app/api/titles/[id]/poster/route.ts
+++ b/src/app/api/titles/[id]/poster/route.ts
@@ -1,0 +1,103 @@
+// PATCH /api/titles/[id]/poster — edit a title's poster_url (URL only; file
+// upload to R2 is a deferred follow-on). Net-new: the existing
+// /api/admin/titles/[slug] PATCH is super-admin-only and doesn't touch
+// poster_url. This route is title-scoped (NOT under /api/admin) so an owning-
+// partner-admin can use it too — authorization is the OR gate, not a path-level
+// admin gate.
+//
+// Authorization is authorizeTitleMutation(user.id, titleId): super_admin OR the
+// partner-admin that OWNS this title. The acting user.id is resolved server-side
+// from the session; the helper resolves ownership internally (never from client
+// input). Service-role write — the helper IS the gate (matches the 5 partner
+// write routes).
+
+import { NextResponse, type NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { getUser } from "@/lib/dal";
+import { enforce } from "@/lib/ratelimit";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import { authorizeTitleMutation } from "@/lib/auth/title-mutation";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Syntactic validation only — we do NOT fetch/verify the image, just ensure a
+// well-formed absolute http(s) URL (rejects empty, non-URL, non-http(s) e.g.
+// javascript:/data:/ftp:).
+function isValidHttpUrl(s: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(s);
+  } catch {
+    return false;
+  }
+  return u.protocol === "http:" || u.protocol === "https:";
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  // Session user, resolved server-side (never trust client identity).
+  const user = await getUser();
+  if (!user) {
+    return NextResponse.json({ error: "not_authenticated" }, { status: 401 });
+  }
+  // Same write-tier limiter the partner routes use.
+  const rl = await enforce("partnerWrites", user.id, "titles/poster");
+  if (!rl.ok) return rl.response;
+
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json({ error: "title_not_found" }, { status: 404 });
+  }
+
+  // AUTHORIZE FIRST — super_admin OR owning-partner-admin. Map the result.
+  const authz = await authorizeTitleMutation(user.id, id);
+  if (!authz.ok) {
+    const status =
+      authz.reason === "not_authenticated"
+        ? 401
+        : authz.reason === "title_not_found"
+          ? 404
+          : 403; // not_authorized
+    return NextResponse.json({ error: authz.reason }, { status });
+  }
+
+  let body: { poster_url?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  const posterUrl =
+    typeof body.poster_url === "string" ? body.poster_url.trim() : "";
+  if (!posterUrl || !isValidHttpUrl(posterUrl)) {
+    return NextResponse.json({ error: "invalid_url" }, { status: 400 });
+  }
+
+  // Write via service-role (authorization already enforced in-app). Scope by the
+  // title's own PK id — the resource is exactly the authorized title.
+  const supabase = createServiceRoleClient();
+  const { data: updated, error } = await supabase
+    .from("titles")
+    .update({ poster_url: posterUrl })
+    .eq("id", id)
+    .select("id, slug, poster_url")
+    .maybeSingle();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  if (!updated) {
+    return NextResponse.json({ error: "title_not_found" }, { status: 404 });
+  }
+
+  // Propagate to the title page; cards elsewhere re-read on their own renders.
+  revalidatePath(`/t/${updated.slug}`);
+
+  return NextResponse.json({
+    ok: true,
+    poster_url: updated.poster_url,
+    via: authz.via,
+  });
+}

--- a/src/lib/auth/title-mutation.ts
+++ b/src/lib/auth/title-mutation.ts
@@ -1,0 +1,94 @@
+// authorizeTitleMutation — the shared authorization gate for content-mutations
+// on a TITLE (poster edit, episode add, …). Mirrors the canonical partner-route
+// pattern (super_admin OR owning-partner-admin) used by the 5 existing
+// /api/p/[slug]/* write routes (e.g. clips/[id] PATCH:50-64 + its title→partner
+// resource-scoping :87-122), lifted into one reusable predicate.
+//
+// LOAD-BEARING — the un-forgeable shape: this takes the SESSION userId and the
+// TITLE id. It does NOT take a partnerId, a role, or any ownership claim from the
+// caller. Ownership is resolved INSIDE the helper from the DB (title → partner_id
+// → partner_users membership) on every call. If it accepted a partnerId, a caller
+// could pass the wrong one and bypass ownership. Same principle as the follow
+// feature's server-side actor resolution.
+//
+// Authorization is application-layer: the title + partner_users reads go through
+// the service-role client (partner_users has RLS with no public SELECT; titles is
+// RLS-gated), exactly as the existing partner routes do. Resources are written via
+// service-role, so THIS helper is the gate.
+
+import { createServiceRoleClient } from "@/lib/supabase/service";
+
+// Discriminated result the callers branch on (FollowOutcome style):
+//   ok:true            → proceed; partnerId lets the write re-scope belt-and-
+//                        suspenders (.eq("partner_id", …)); `via` is for logging.
+//   not_authenticated  → no session userId (caller 401s)
+//   title_not_found    → no live title with that id (caller 404s, NOT 403)
+//   not_authorized     → authenticated but not allowed (caller 403s)
+export type AuthzResult =
+  | {
+      ok: true;
+      titleId: string;
+      partnerId: string | null;
+      via: "super_admin" | "partner_admin";
+    }
+  | { ok: false; reason: "not_authenticated" }
+  | { ok: false; reason: "title_not_found" }
+  | { ok: false; reason: "not_authorized" };
+
+export async function authorizeTitleMutation(
+  userId: string,
+  titleId: string,
+): Promise<AuthzResult> {
+  // The caller passes the session userId (from getUser()/verifySession). Guard
+  // defensively — an empty/absent id is never authorized.
+  if (!userId) return { ok: false, reason: "not_authenticated" };
+
+  const supabase = createServiceRoleClient();
+
+  // 1. Acting user's role + 2. the title (id, owning partner). Both service-role.
+  //    The title is soft-delete-scoped (deleted_at IS NULL) exactly as titles are
+  //    read everywhere else (title-access.ts, queries/titles.ts).
+  const [{ data: userRow }, { data: title }] = await Promise.all([
+    supabase.from("users").select("role").eq("id", userId).maybeSingle(),
+    supabase
+      .from("titles")
+      .select("id, partner_id")
+      .eq("id", titleId)
+      .is("deleted_at", null)
+      .maybeSingle(),
+  ]);
+
+  // 2b. No live title → 404 (distinct from 403 so the caller can branch). This
+  //     precedes the role check: nobody, not even a super-admin, mutates a title
+  //     that doesn't exist.
+  if (!title) return { ok: false, reason: "title_not_found" };
+
+  const role = (userRow?.role as string | null) ?? null;
+  const partnerId = (title.partner_id as string | null) ?? null;
+
+  // 3. Super-admin bypasses the partner check entirely (per precedent), but is
+  //    still only authorized for a real title (checked above).
+  if (role === "super_admin") {
+    return { ok: true, titleId, partnerId, via: "super_admin" };
+  }
+
+  // 4. Unowned title (general catalog) → super-admin only. The partner branch
+  //    can't match a NULL partner_id, so deny.
+  if (partnerId === null) return { ok: false, reason: "not_authorized" };
+
+  // 5. Owning-partner-admin: a live partner_users membership for THIS title's
+  //    partner, role 'admin' (mirrors all 5 partner write routes — not loosened
+  //    to any partner role).
+  const { data: membership } = await supabase
+    .from("partner_users")
+    .select("role")
+    .eq("partner_id", partnerId)
+    .eq("user_id", userId)
+    .is("deleted_at", null)
+    .maybeSingle();
+  if (membership && membership.role === "admin") {
+    return { ok: true, titleId, partnerId, via: "partner_admin" };
+  }
+
+  return { ok: false, reason: "not_authorized" };
+}


### PR DESCRIPTION
**Draft — do not merge.** Authenticated preview review.

**⚠ Stacked on the helper:** this branch includes `feature/authorize-title-mutation` (`756415a`), which is **not yet on main**. The helper must merge first (or this branch carries both). The PR diff therefore shows the helper + Unit 1.

Unit 1: edit a title's `poster_url` (URL only; R2 upload deferred). Fixes the missing edit path so fragile/broken posters (Watch Hill → image2url.com) can be replaced.

- **Route** (net-new): `PATCH /api/titles/[id]/poster` — title-scoped (not `/api/admin`, so owning-partner-admins can use it). `authorizeTitleMutation` gate; result→HTTP 401/404/403/200; `partnerWrites` limit; http(s)-URL validation; service-role write scoped by title PK; revalidates `/t/[slug]`.
- **UI**: Poster section in the super-admin Settings tab (`/admin/titles/[slug]`) — current-poster preview (broken → "⚠ failed to load"), prefilled input, Save. Partner-facing surface on `/p/[slug]` is a deferred follow-on (API already authorizes partners).

### Preview review (super-admin = you)
- [ ] `/admin/titles/watch-hill-2026` → **Settings** tab → Poster: see current (image2url.com) preview, paste a durable image URL, Save
- [ ] `/t/watch-hill-2026` shows the new poster; cards too
- [ ] malformed/empty URL → rejected (no save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)