### PR TITLE
fix(image): allowlist R2 public host for next/image (poster render)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -43,6 +43,15 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "image.tmdb.org",
       },
+      {
+        // R2 public bucket — durable poster/asset host (R2_PUBLIC_URL's
+        // host; same value stored in titles.poster_url / partners.logo_url,
+        // not a secret). Required so next/image (TitlePosterShared, TitleCard)
+        // can optimize R2-hosted posters; without it the optimizer 400s →
+        // broken placeholder. Exact host, not a wildcard.
+        protocol: "https",
+        hostname: "pub-8dcc0cdf788945bc87b3931edd0bb800.r2.dev",
+      },
     ],
   },
   async redirects() {


### PR DESCRIPTION
**Draft — do not merge.** Part A: the poster render fix.

Posters use next/image; the optimizer rejects hosts not in `images.remotePatterns` → broken placeholder. The R2 public host wasn't allowlisted. Adds the exact host (not wildcard). Fixes the already-uploaded Watch Hill object **without re-upload**. Additive (tmdb/squarespace unchanged). Part B (inline disposition) deferred — cosmetic.

### Preview check (Watch Hill now public → test as ANON)
- [ ] `/t/watch-hill-2026` logged-out → real poster renders (not broken placeholder)
- [ ] Watch Hill card on homepage/search renders its poster (anon)
- [ ] existing tmdb/squarespace posters still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)