### PR TITLE
title: bulk-add Instagram episodes (the title_episodes write path)

### DIFF
--- a/src/app/admin/titles/[slug]/TitleDetailTabs.tsx
+++ b/src/app/admin/titles/[slug]/TitleDetailTabs.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import FanEditsUploadCard from "@/components/admin/FanEditsUploadCard";
 import UploadClient from "./upload/UploadClient";
@@ -1307,6 +1307,165 @@ function PosterEditor({
   );
 }
 
+// Bulk-append Instagram episodes to the Watch tab. Paste one URL per line;
+// optional "| Label" after the URL. The client splits URL/label; the SERVER
+// validates/normalizes the IG URLs, assigns episode numbers (max+1, paste
+// order), and inserts. Append-only (no edit/delete UI by design).
+type EpisodeAddResult = {
+  added: number;
+  skipped: Array<{ line: number; url: string; reason: string }>;
+  errors: Array<{ line: number; url: string; error: string }>;
+};
+
+function EpisodesEditor({
+  titleId,
+  titleSlug,
+}: {
+  titleId: string;
+  titleSlug: string;
+}) {
+  const [text, setText] = useState("");
+  const [state, setState] = useState<"idle" | "submitting" | "done" | "error">(
+    "idle",
+  );
+  const [result, setResult] = useState<EpisodeAddResult | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // One non-empty line = one episode. URL first; optional label after the FIRST
+  // "|" (pipe — unambiguous, neither URLs nor labels normally contain it).
+  const items = useMemo(
+    () =>
+      text
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .map((line) => {
+          const idx = line.indexOf("|");
+          const url = (idx === -1 ? line : line.slice(0, idx)).trim();
+          const label = idx === -1 ? undefined : line.slice(idx + 1).trim();
+          return label ? { url, label } : { url };
+        }),
+    [text],
+  );
+
+  async function submit() {
+    if (items.length === 0 || state === "submitting") return;
+    setState("submitting");
+    setErrorMsg(null);
+    setResult(null);
+    try {
+      const res = await fetch(`/api/titles/${titleId}/episodes`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ items }),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        added?: number;
+        skipped?: EpisodeAddResult["skipped"];
+        errors?: EpisodeAddResult["errors"];
+        error?: string;
+      };
+      if (!res.ok || !json.ok) {
+        setState("error");
+        setErrorMsg(json.error ?? `request failed (${res.status})`);
+        return;
+      }
+      setResult({
+        added: json.added ?? 0,
+        skipped: json.skipped ?? [],
+        errors: json.errors ?? [],
+      });
+      setState("done");
+      if ((json.added ?? 0) > 0) setText(""); // clear on a successful add
+    } catch (err) {
+      setState("error");
+      setErrorMsg(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+      <h2 className="m-0 text-body font-medium text-moonbeem-ink">Episodes</h2>
+      <p className="mt-1 text-caption text-moonbeem-ink-subtle">
+        Paste Instagram post/reel URLs, one per line — appended to the{" "}
+        <code className="font-mono">/t/{titleSlug}</code> Watch tab in paste
+        order. Optional label after a <code className="font-mono">|</code> (e.g.{" "}
+        <code className="font-mono">
+          https://instagram.com/reel/XXXX/ | Opening scene
+        </code>
+        ); no label → <span className="font-mono">Episode N</span>.
+      </p>
+
+      <textarea
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value);
+          if (state !== "idle") setState("idle");
+        }}
+        rows={8}
+        placeholder={
+          "https://www.instagram.com/reel/XXXXXXXXX/\nhttps://www.instagram.com/p/YYYYYYYYY/ | Behind the scenes"
+        }
+        className="mt-4 w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 font-mono text-caption text-moonbeem-ink focus:border-moonbeem-pink focus:outline-none"
+      />
+      <div className="mt-3 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={submit}
+          disabled={items.length === 0 || state === "submitting"}
+          className="rounded-md bg-moonbeem-pink px-4 py-2 text-body-sm font-semibold text-moonbeem-navy transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {state === "submitting"
+            ? "Adding…"
+            : `Add ${items.length} episode${items.length === 1 ? "" : "s"}`}
+        </button>
+        <span className="text-caption text-moonbeem-ink-subtle">
+          {items.length} line{items.length === 1 ? "" : "s"} parsed
+        </span>
+      </div>
+
+      {result && (
+        <div className="mt-3 flex flex-col gap-1">
+          <p className="m-0 text-caption text-emerald-300">
+            Added {result.added}.
+            {result.skipped.length > 0
+              ? ` Skipped ${result.skipped.length} already present.`
+              : ""}
+          </p>
+          {result.errors.length > 0 && (
+            <div className="text-caption text-moonbeem-magenta">
+              <p className="m-0">
+                {result.errors.length} line
+                {result.errors.length === 1 ? "" : "s"} not added:
+              </p>
+              <ul className="m-0 mt-1 list-disc pl-5">
+                {result.errors.map((e) => (
+                  <li key={e.line}>
+                    Line {e.line}: {e.error}
+                    {e.url ? ` — ${e.url}` : ""}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {result.added > 0 && (
+            <Link
+              href={`/t/${titleSlug}`}
+              className="m-0 w-fit text-caption text-moonbeem-ink-muted hover:text-moonbeem-pink"
+            >
+              View Watch tab →
+            </Link>
+          )}
+        </div>
+      )}
+      {errorMsg && (
+        <p className="m-0 mt-2 text-caption text-moonbeem-magenta">{errorMsg}</p>
+      )}
+    </section>
+  );
+}
+
 type SettingsState = "idle" | "saving" | "error";
 
 function SettingsTab({
@@ -1463,6 +1622,8 @@ function SettingsTab({
         titleSlug={slug}
         initialPosterUrl={initialPosterUrl}
       />
+
+      <EpisodesEditor titleId={titleId} titleSlug={slug} />
 
       <section className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
         <h2 className="m-0 text-body font-medium text-moonbeem-ink">

--- a/src/app/api/titles/[id]/episodes/route.ts
+++ b/src/app/api/titles/[id]/episodes/route.ts
@@ -1,0 +1,204 @@
+// POST /api/titles/[id]/episodes — bulk-append Instagram episodes to a title's
+// Watch tab. Net-new write path for title_episodes (it had a live READ path but
+// no writer). Title-generic (NOT /api/admin) so owning-partner-admins are
+// authorized via the OR gate. Instagram-source only in v1 (mux episodes arrive
+// via the U2 ingest webhook — a different path).
+//
+// Authorization: authorizeTitleMutation(user.id, titleId) — super_admin OR the
+// owning-partner-admin. Same gate + status mapping as the poster route.
+//
+// APPEND semantics: episode_number is assigned SERVER-SIDE as max+1.. in PASTE
+// ORDER (the client never supplies it). So a second batch continues numbering
+// and doesn't collide; the (title_id, episode_number) unique backstops races.
+
+import { NextResponse, type NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { getUser } from "@/lib/dal";
+import { enforce } from "@/lib/ratelimit";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import { authorizeTitleMutation } from "@/lib/auth/title-mutation";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Cap per batch — a paste can't insert unbounded rows. 39 (Watch Hill) fits.
+const MAX_ITEMS = 100;
+
+// Recognize an Instagram POST or REEL URL and rebuild the CANONICAL form,
+// dropping query (?igsh=…/?utm=…) and fragment by reconstructing from the
+// shortcode. Accepts p / reel / reels (reels→reel), with/without www/m,
+// with/without trailing slash. Returns null for anything unrecognizable.
+function normalizeInstagramUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  // Tolerate a pasted URL with no scheme (instagram.com/reel/… ).
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  let u: URL;
+  try {
+    u = new URL(withScheme);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== "https:" && u.protocol !== "http:") return null;
+  const host = u.hostname.toLowerCase().replace(/^m\./, "").replace(/^www\./, "");
+  if (host !== "instagram.com") return null;
+  const m = u.pathname.match(/^\/(p|reel|reels)\/([A-Za-z0-9_-]+)\/?$/i);
+  if (!m) return null;
+  const kind = m[1].toLowerCase() === "p" ? "p" : "reel";
+  const shortcode = m[2];
+  return `https://www.instagram.com/${kind}/${shortcode}/`;
+}
+
+type InItem = { url?: unknown; label?: unknown };
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const user = await getUser();
+  if (!user) {
+    return NextResponse.json({ error: "not_authenticated" }, { status: 401 });
+  }
+  const rl = await enforce("partnerWrites", user.id, "titles/episodes");
+  if (!rl.ok) return rl.response;
+
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json({ error: "title_not_found" }, { status: 404 });
+  }
+
+  // AUTHORIZE FIRST — same gate + mapping as the poster route.
+  const authz = await authorizeTitleMutation(user.id, id);
+  if (!authz.ok) {
+    const status =
+      authz.reason === "not_authenticated"
+        ? 401
+        : authz.reason === "title_not_found"
+          ? 404
+          : 403;
+    return NextResponse.json({ error: authz.reason }, { status });
+  }
+
+  let body: { items?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  const rawItems = Array.isArray(body.items) ? (body.items as InItem[]) : null;
+  if (!rawItems || rawItems.length === 0) {
+    return NextResponse.json({ error: "empty_list" }, { status: 400 });
+  }
+  if (rawItems.length > MAX_ITEMS) {
+    return NextResponse.json(
+      { error: "too_many", max: MAX_ITEMS, got: rawItems.length },
+      { status: 400 },
+    );
+  }
+
+  const supabase = createServiceRoleClient();
+
+  // Existing embed_urls for this title — soft dedup (no UNIQUE constraint in
+  // v1; see recommendation in the report). Re-running an identical batch then
+  // no-ops (all skipped) instead of double-adding.
+  const { data: existingRows } = await supabase
+    .from("title_episodes")
+    .select("embed_url")
+    .eq("title_id", id);
+  const existing = new Set(
+    (existingRows ?? []).map((r) => r.embed_url as string),
+  );
+
+  // Parse + validate + dedup, preserving paste order. errors are per-line
+  // (1-based index); skipped = recognized-but-duplicate.
+  const errors: Array<{ line: number; url: string; error: string }> = [];
+  const skipped: Array<{ line: number; url: string; reason: string }> = [];
+  const seenInBatch = new Set<string>();
+  const toInsert: Array<{ embedUrl: string; label: string | null }> = [];
+
+  rawItems.forEach((it, i) => {
+    const line = i + 1;
+    const rawUrl = typeof it.url === "string" ? it.url.trim() : "";
+    const rawLabel =
+      typeof it.label === "string" && it.label.trim() ? it.label.trim() : null;
+    if (!rawUrl) {
+      errors.push({ line, url: "", error: "missing_url" });
+      return;
+    }
+    const canonical = normalizeInstagramUrl(rawUrl);
+    if (!canonical) {
+      errors.push({ line, url: rawUrl, error: "not_an_instagram_post_or_reel" });
+      return;
+    }
+    if (seenInBatch.has(canonical) || existing.has(canonical)) {
+      skipped.push({ line, url: canonical, reason: "already_present" });
+      return;
+    }
+    seenInBatch.add(canonical);
+    toInsert.push({ embedUrl: canonical, label: rawLabel });
+  });
+
+  if (toInsert.length === 0) {
+    return NextResponse.json({ ok: true, added: 0, skipped, errors });
+  }
+
+  // Server-assigned numbering: max(episode_number)+1.. in paste order.
+  const { data: maxRow } = await supabase
+    .from("title_episodes")
+    .select("episode_number")
+    .eq("title_id", id)
+    .order("episode_number", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const base = (maxRow?.episode_number as number | null) ?? 0;
+
+  // Build rows. source='instagram' → embed_url set, mux fields untouched (null)
+  // → satisfies title_episodes_source_shape_check. monetization_mode NULL
+  // inherits the title default (Watch Hill: 'free') via the U1 COALESCE rule.
+  const rows = toInsert.map((r, idx) => {
+    const episodeNumber = base + idx + 1;
+    return {
+      title_id: id,
+      episode_number: episodeNumber,
+      label: r.label ?? `Episode ${episodeNumber}`,
+      embed_url: r.embedUrl,
+      source: "instagram",
+      is_published: true,
+      requires_drm: false,
+      monetization_mode: null,
+    };
+  });
+
+  // One atomic insert — all rows or none (a mid-batch failure won't leave a
+  // half-added series). A 23505 means a concurrent batch took the numbers.
+  const { data: inserted, error: insErr } = await supabase
+    .from("title_episodes")
+    .insert(rows)
+    .select("id");
+  if (insErr) {
+    const conflict = insErr.code === "23505";
+    return NextResponse.json(
+      {
+        error: conflict ? "numbering_conflict_retry" : insErr.message,
+      },
+      { status: conflict ? 409 : 500 },
+    );
+  }
+
+  // Resolve the slug to revalidate the public Watch tab.
+  const { data: title } = await supabase
+    .from("titles")
+    .select("slug")
+    .eq("id", id)
+    .maybeSingle();
+  if (title?.slug) revalidatePath(`/t/${title.slug}`);
+
+  return NextResponse.json({
+    ok: true,
+    added: inserted?.length ?? rows.length,
+    first_episode_number: base + 1,
+    last_episode_number: base + rows.length,
+    skipped,
+    errors,
+    via: authz.via,
+  });
+}


### PR DESCRIPTION
**Draft — do not merge.** Net-new writer for `title_episodes` (Watch tab had a read path, no writer). Lean append tool; Watch Hill = first caller.

- `POST /api/titles/[id]/episodes` — `authorizeTitleMutation` gate; body `{items:[{url,label?}]}`; IG post/reel normalization (query-stripped, per-line errors); **server-assigned** `episode_number` (max+1, paste order); cap 100; soft dedup (no UNIQUE in v1); one atomic insert (`source=instagram`, mux null → satisfies U1 shape CHECK, `monetization_mode` NULL inherits default).
- UI: Episodes textarea in the Settings tab (`| Label` optional), parsed-count + added/skipped/errored result.

Verified: IG normalization (10 cases), insert shape + numbering + append-correctness on Watch Hill (test rows deleted, baseline 0). tsc + build clean.

### Preview (super-admin = you)
- [ ] `/admin/titles/watch-hill-2026` → Settings → Episodes: paste 2-3 real IG reel URLs → "Added N" → they render in the Watch tab + open in the modal (vertical Reels)
- [ ] a non-IG line → per-line error; a `?igsh=` URL → stored stripped
- [ ] **DELETE the test rows after** (before the real 39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)