### PR TITLE
title: episode cover thumbnails (auto-derive IG → R2, best-effort)

### DIFF
--- a/src/app/admin/titles/[slug]/TitleDetailTabs.tsx
+++ b/src/app/admin/titles/[slug]/TitleDetailTabs.tsx
@@ -1330,6 +1330,15 @@ function EpisodesEditor({
   );
   const [result, setResult] = useState<EpisodeAddResult | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [thumbState, setThumbState] = useState<
+    "idle" | "running" | "done" | "error"
+  >("idle");
+  const [thumbResult, setThumbResult] = useState<{
+    enriched: number;
+    failed: number;
+    remaining: number;
+  } | null>(null);
+  const [thumbError, setThumbError] = useState<string | null>(null);
 
   // One non-empty line = one episode. URL first; optional label after the FIRST
   // "|" (pipe — unambiguous, neither URLs nor labels normally contain it).
@@ -1381,6 +1390,40 @@ function EpisodesEditor({
     } catch (err) {
       setState("error");
       setErrorMsg(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  // Best-effort cover enrichment: auto-derive IG covers, re-host to R2. Capped +
+  // re-runnable — click again while remaining > 0.
+  async function fetchThumbnails() {
+    if (thumbState === "running") return;
+    setThumbState("running");
+    setThumbError(null);
+    try {
+      const res = await fetch(`/api/titles/${titleId}/episodes/thumbnails`, {
+        method: "POST",
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        enriched?: number;
+        failed?: number;
+        remaining?: number;
+        error?: string;
+      };
+      if (!res.ok || !json.ok) {
+        setThumbState("error");
+        setThumbError(json.error ?? `request failed (${res.status})`);
+        return;
+      }
+      setThumbResult({
+        enriched: json.enriched ?? 0,
+        failed: json.failed ?? 0,
+        remaining: json.remaining ?? 0,
+      });
+      setThumbState("done");
+    } catch (err) {
+      setThumbState("error");
+      setThumbError(err instanceof Error ? err.message : String(err));
     }
   }
 
@@ -1462,6 +1505,42 @@ function EpisodesEditor({
       {errorMsg && (
         <p className="m-0 mt-2 text-caption text-moonbeem-magenta">{errorMsg}</p>
       )}
+
+      {/* Cover thumbnails — best-effort auto-derive from Instagram, re-hosted to
+          R2. Decoupled from the add above; re-runnable for any remaining. */}
+      <div className="mt-5 border-t border-white/10 pt-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={fetchThumbnails}
+            disabled={thumbState === "running"}
+            className="rounded-md border border-white/15 bg-white/5 px-3 py-1.5 text-body-sm text-moonbeem-ink transition-colors hover:border-moonbeem-pink hover:text-moonbeem-pink disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {thumbState === "running" ? "Fetching covers…" : "Fetch thumbnails"}
+          </button>
+          <span className="text-caption text-moonbeem-ink-subtle">
+            Auto-derives Instagram covers (re-hosted to R2). Failures keep the
+            numbered tile; re-run for any remaining.
+          </span>
+        </div>
+        {thumbResult && (
+          <p className="m-0 mt-2 text-caption text-emerald-300">
+            Enriched {thumbResult.enriched}
+            {thumbResult.failed > 0
+              ? `, ${thumbResult.failed} failed (kept numbered tile)`
+              : ""}
+            .
+            {thumbResult.remaining > 0
+              ? ` ${thumbResult.remaining} remaining — click again to continue.`
+              : " All covered."}
+          </p>
+        )}
+        {thumbError && (
+          <p className="m-0 mt-2 text-caption text-moonbeem-magenta">
+            {thumbError}
+          </p>
+        )}
+      </div>
     </section>
   );
 }

--- a/src/app/api/titles/[id]/episodes/thumbnails/route.ts
+++ b/src/app/api/titles/[id]/episodes/thumbnails/route.ts
@@ -1,0 +1,203 @@
+// POST /api/titles/[id]/episodes/thumbnails — best-effort, re-runnable cover
+// enrichment. Auto-derives an Instagram cover for each title_episodes row that
+// still has cover_image_url IS NULL, RE-HOSTS it to R2, and stores the durable
+// R2 url. DECOUPLED from the bulk-add route (which never sets covers) — this is
+// pure presentation enrichment, money-rail-free, Mux-independent.
+//
+// Re-runnable: each call processes only still-null episodes (up to a cap), so
+// re-running picks up whatever remains (or what failed last time). A per-episode
+// failure (fetch 403/timeout/non-image, R2 error) is caught + skipped → that
+// episode keeps cover_image_url NULL → EpisodeList renders the numbered tile. A
+// failure NEVER errors the pass or any sibling episode.
+//
+// NOTE: the IG media-redirect (…/media/?size=l → 302 → cdninstagram .jpg) is
+// tokenless and worked from a non-Vercel probe; whether Vercel's datacenter IPs
+// are blocked/rate-limited by IG is the open question this route's first run
+// answers. We NEVER store the cdninstagram url (signed/expiring/hotlink-blocked
+// — the temp-host fragility we already fixed); we re-host the bytes to R2.
+
+import { NextResponse, type NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { getUser } from "@/lib/dal";
+import { enforce } from "@/lib/ratelimit";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { authorizeTitleMutation } from "@/lib/auth/title-mutation";
+import { buildEpisodeThumbKey, buildPublicUrl } from "@/lib/r2/upload";
+import { getR2Bucket, getR2Client } from "@/lib/r2/client";
+
+// The S3 SDK needs Node APIs (not Edge); the IG fetch + R2 uploads need headroom.
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Per-invocation cap: keep one request well within the function timeout. With
+// CONCURRENCY=4 and a 5s per-fetch timeout, 12 episodes = ~3 waves ≈ 15s worst
+// case — comfortable under maxDuration. Re-run to continue (remaining>0).
+const PER_INVOCATION_CAP = 12;
+const CONCURRENCY = 4;
+const FETCH_TIMEOUT_MS = 5000;
+
+const BROWSER_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36";
+
+// Pull the IG shortcode out of the canonical embed_url
+// (https://www.instagram.com/{p|reel|reels}/{shortcode}/).
+function shortcodeOf(embedUrl: string): string | null {
+  const m = embedUrl.match(/\/(?:p|reel|reels)\/([A-Za-z0-9_-]+)\/?$/i);
+  return m ? m[1] : null;
+}
+
+async function fetchWithTimeout(url: string, ms: number): Promise<Response> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), ms);
+  try {
+    return await fetch(url, {
+      headers: { "user-agent": BROWSER_UA, accept: "image/*,*/*" },
+      redirect: "follow",
+      signal: ctrl.signal,
+    });
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+// Derive + re-host + persist one episode's cover. Returns "ok" | "fail".
+// Throws nothing — every failure mode resolves to "fail".
+async function deriveAndStore(
+  supabase: SupabaseClient,
+  titleSlug: string,
+  ep: { id: string; embed_url: string },
+): Promise<"ok" | "fail"> {
+  try {
+    const sc = shortcodeOf(ep.embed_url);
+    if (!sc) return "fail";
+
+    const res = await fetchWithTimeout(
+      `https://www.instagram.com/p/${sc}/media/?size=l`,
+      FETCH_TIMEOUT_MS,
+    );
+    if (!res.ok) return "fail";
+    const ctype = (res.headers.get("content-type") ?? "").split(";")[0].trim();
+    if (!ctype.startsWith("image/")) return "fail"; // login wall / html / etc.
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    if (bytes.byteLength === 0) return "fail";
+
+    // Re-host to R2 (server-side PutObject — NOT a presigned browser PUT, and no
+    // Content-Disposition so it serves inline). Stable key per shortcode.
+    const key = buildEpisodeThumbKey(titleSlug, sc);
+    await getR2Client().send(
+      new PutObjectCommand({
+        Bucket: getR2Bucket(),
+        Key: key,
+        Body: bytes,
+        ContentType: ctype,
+      }),
+    );
+    const url = buildPublicUrl(key);
+
+    // Persist the R2 url (NEVER the cdninstagram url). Guard with IS NULL so a
+    // concurrent run can't double-write, and CONFIRM via the returned row
+    // (select-confirm, not rowsAffected).
+    const { data: updated, error } = await supabase
+      .from("title_episodes")
+      .update({ cover_image_url: url })
+      .eq("id", ep.id)
+      .is("cover_image_url", null)
+      .select("id, cover_image_url")
+      .maybeSingle();
+    if (error || !updated || updated.cover_image_url !== url) return "fail";
+    return "ok";
+  } catch (err) {
+    console.warn(
+      `[episode-thumb] ${ep.id} failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return "fail";
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const user = await getUser();
+  if (!user) {
+    return NextResponse.json({ error: "not_authenticated" }, { status: 401 });
+  }
+  const rl = await enforce("partnerWrites", user.id, "titles/episode-thumbs");
+  if (!rl.ok) return rl.response;
+
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json({ error: "title_not_found" }, { status: 404 });
+  }
+
+  // AUTHORIZE FIRST — same gate + mapping as the poster + episodes routes.
+  const authz = await authorizeTitleMutation(user.id, id);
+  if (!authz.ok) {
+    const status =
+      authz.reason === "not_authenticated"
+        ? 401
+        : authz.reason === "title_not_found"
+          ? 404
+          : 403;
+    return NextResponse.json({ error: authz.reason }, { status });
+  }
+
+  const supabase = createServiceRoleClient();
+
+  const { data: title } = await supabase
+    .from("titles")
+    .select("slug")
+    .eq("id", id)
+    .maybeSingle();
+  if (!title) {
+    return NextResponse.json({ error: "title_not_found" }, { status: 404 });
+  }
+  const titleSlug = title.slug as string;
+
+  // Total still-null instagram covers (for the remaining count).
+  const { count: totalNull } = await supabase
+    .from("title_episodes")
+    .select("id", { count: "exact", head: true })
+    .eq("title_id", id)
+    .eq("source", "instagram")
+    .is("cover_image_url", null);
+
+  // This invocation's batch (capped) — only still-null instagram episodes, in
+  // episode order. The IS NULL filter is what makes a re-run skip populated rows.
+  const { data: batchRows } = await supabase
+    .from("title_episodes")
+    .select("id, embed_url")
+    .eq("title_id", id)
+    .eq("source", "instagram")
+    .is("cover_image_url", null)
+    .order("episode_number", { ascending: true })
+    .limit(PER_INVOCATION_CAP);
+  const batch = (batchRows ?? []) as Array<{ id: string; embed_url: string }>;
+
+  let enriched = 0;
+  let failed = 0;
+  for (let i = 0; i < batch.length; i += CONCURRENCY) {
+    const slice = batch.slice(i, i + CONCURRENCY);
+    const results = await Promise.all(
+      slice.map((ep) => deriveAndStore(supabase, titleSlug, ep)),
+    );
+    for (const r of results) r === "ok" ? enriched++ : failed++;
+  }
+
+  if (enriched > 0) revalidatePath(`/t/${titleSlug}`);
+
+  const remaining = Math.max(0, (totalNull ?? batch.length) - enriched);
+  return NextResponse.json({
+    ok: true,
+    processed: batch.length,
+    enriched,
+    failed,
+    remaining,
+    via: authz.via,
+  });
+}

--- a/src/lib/r2/upload.ts
+++ b/src/lib/r2/upload.ts
@@ -90,3 +90,16 @@ export function buildPartnerLogoKey(slug: string, ext: string): string {
 export function buildPosterKey(titleSlug: string, ext: string): string {
   return `posters/${titleSlug}/${Date.now()}.${safeExt(ext)}`;
 }
+
+// episodes/<titleSlug>/<shortcode>.jpg — a per-episode cover thumbnail re-hosted
+// from Instagram. STABLE key (the IG shortcode is immutable and its cover doesn't
+// change), so a re-host overwrites the same object idempotently — no orphan
+// accumulation. The caller passes an already-validated IG shortcode
+// ([A-Za-z0-9_-], so safe for a key); titleSlug is slug-safe. Always .jpg (the
+// IG media endpoint returns JPEG).
+export function buildEpisodeThumbKey(
+  titleSlug: string,
+  shortcode: string,
+): string {
+  return `episodes/${titleSlug}/${shortcode}.jpg`;
+}


### PR DESCRIPTION
**Draft — do not merge.** Populates `title_episodes.cover_image_url` so the Watch tab shows covers. Column already existed; EpisodeList already renders it. Decoupled, presentation-only.

`POST /api/titles/[id]/episodes/thumbnails` — `authorizeTitleMutation` gate; processes `source='instagram' AND cover_image_url IS NULL` (re-runnable), cap 12, concurrency 4, 5s timeout; per episode: `media/?size=l` → bytes → **R2 re-host** (never the cdninstagram URL) → UPDATE (select-confirmed). Best-effort: failures keep the numbered tile, never error the pass.

### ⚠ THE DECISIVE EGRESS CHECK (yours — needs a super-admin click)
I can't mint a super-admin session headlessly, so the Vercel→IG egress result is your one click. **Watch Hill already has your 5 real episodes (covers null), so it's set up:**
- [ ] `/admin/titles/watch-hill-2026` → Settings → Episodes → **Fetch thumbnails**
- [ ] Report **enriched/failed**. If enriched>0 → Vercel egress works; `cover_image_url` now a `pub-…r2.dev/episodes/…` URL (NOT cdninstagram); covers render in the Watch tab.
- [ ] If enriched=0/all failed → IG is blocking Vercel IPs → we pivot to manual cover-upload (separate build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)