### PR TITLE
fix(watch): enlarge EpisodeModal on desktop (CSS-only)

### DIFF
--- a/src/components/EpisodeModal.tsx
+++ b/src/components/EpisodeModal.tsx
@@ -58,7 +58,7 @@ export default function EpisodeModal({
             exit={{ opacity: 0, scale: 0.98 }}
             transition={{ duration: 0.22, ease: "easeOut" }}
             onClick={stop}
-            className="relative z-10 flex h-full w-full flex-col bg-moonbeem-black md:h-auto md:max-h-[90vh] md:w-auto md:max-w-[440px] md:overflow-hidden md:rounded-2xl md:border md:border-white/10 md:shadow-2xl md:shadow-black/60"
+            className="relative z-10 flex h-full w-full flex-col bg-moonbeem-black md:h-auto md:max-h-[90vh] md:w-auto md:max-w-[600px] md:overflow-hidden md:rounded-2xl md:border md:border-white/10 md:shadow-2xl md:shadow-black/60"
           >
             <div className="flex items-center justify-between gap-3 border-b border-white/10 px-4 py-3">
               <span className="truncate text-body-sm font-medium text-moonbeem-ink">
@@ -74,7 +74,7 @@ export default function EpisodeModal({
               </button>
             </div>
             <div className="flex flex-1 items-start justify-center overflow-y-auto bg-moonbeem-navy/20 p-3">
-              <div className="w-full max-w-[400px]">
+              <div className="w-full max-w-[540px]">
                 <InstagramEmbed
                   url={episode.embed_url}
                   width="100%"


### PR DESCRIPTION
**Draft — do not merge.** Watch-tab player polish (recon GOAL B). CSS-only.

- embed wrapper `max-w-[400px]` → `max-w-[540px]` (IG natural max)
- desktop dialog `md:max-w-[440px]` → `md:max-w-[600px]`
- `md:max-h-[90vh]` kept (tall vertical Reels scroll); mobile full-screen untouched
- no Fullscreen API (IG card, not a video we control — deferred to Mux player)

### Preview check
- [ ] desktop `/t/watch-hill-2026` → Watch → open an episode: modal visibly larger, embed ~540 wide, tall vertical Reel scrolls within the modal (no clipping)
- [ ] mobile (narrow viewport): unchanged, full-screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)