### PR TITLE
title: metadata editor (5-field Details form, super-admin OR owning-partner-admin)

### DIFF
--- a/src/app/admin/titles/[slug]/TitleDetailTabs.tsx
+++ b/src/app/admin/titles/[slug]/TitleDetailTabs.tsx
@@ -103,6 +103,14 @@ export type AnalyticsData = {
   fanEditsComparison: AnalyticsFanEditRow[];
 };
 
+export type TitleMetadata = {
+  synopsis: string | null;
+  year: number | null;
+  runtime_min: number | null;
+  director: string | null;
+  starring_csv: string | null;
+};
+
 type Props = {
   titleId: string;
   titleSlug: string;
@@ -114,6 +122,7 @@ type Props = {
   partnerSlug: string | null;
   hasPartner: boolean;
   posterUrl: string | null;
+  metadata: TitleMetadata;
   allPartners: PartnerOption[];
   fanEdits: FanEditRow[];
   clips: ClipRow[];
@@ -310,6 +319,7 @@ export default function TitleDetailTabs(props: Props) {
               slug={props.titleSlug}
               titleName={props.titleName}
               initialPosterUrl={props.posterUrl}
+              initialMetadata={props.metadata}
               initialIsActive={props.isActive}
               initialIsPublic={props.isPublic}
               initialPartnerId={props.partnerId}
@@ -1545,6 +1555,229 @@ function EpisodesEditor({
   );
 }
 
+// Metadata editor — the 5 rendered About-tab fields. Partial PATCH: each Save
+// sends only the changed fields. tagline/overview/genres are intentionally
+// absent (dead columns). starring_csv is a comma-separated name list.
+function DetailsEditor({
+  titleId,
+  titleSlug,
+  initialMetadata,
+}: {
+  titleId: string;
+  titleSlug: string;
+  initialMetadata: TitleMetadata;
+}) {
+  // Saved = the last server-confirmed values; form = the editable strings.
+  const [saved, setSaved] = useState<TitleMetadata>(initialMetadata);
+  const [synopsis, setSynopsis] = useState(initialMetadata.synopsis ?? "");
+  const [year, setYear] = useState(
+    initialMetadata.year != null ? String(initialMetadata.year) : "",
+  );
+  const [runtime, setRuntime] = useState(
+    initialMetadata.runtime_min != null
+      ? String(initialMetadata.runtime_min)
+      : "",
+  );
+  const [director, setDirector] = useState(initialMetadata.director ?? "");
+  const [starring, setStarring] = useState(initialMetadata.starring_csv ?? "");
+  const [state, setState] = useState<"idle" | "saving" | "saved" | "error">(
+    "idle",
+  );
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Build the partial body of ONLY changed fields (PATCH semantics). Empty
+  // string → null (clears the field). year/runtime sent as the trimmed string;
+  // the route validates + coerces.
+  function changedFields(): Record<string, string | number | null> | "invalid" {
+    const out: Record<string, string | number | null> = {};
+    const synN = synopsis.trim() || null;
+    if (synN !== (saved.synopsis ?? null)) out.synopsis = synN;
+    const dirN = director.trim() || null;
+    if (dirN !== (saved.director ?? null)) out.director = dirN;
+    const starN = starring.trim() || null;
+    if (starN !== (saved.starring_csv ?? null)) out.starring_csv = starN;
+
+    const yTrim = year.trim();
+    const yVal = yTrim === "" ? null : Number(yTrim);
+    if (yTrim !== "" && !Number.isInteger(yVal)) return "invalid";
+    if ((yVal ?? null) !== (saved.year ?? null)) out.year = yVal;
+
+    const rTrim = runtime.trim();
+    const rVal = rTrim === "" ? null : Number(rTrim);
+    if (rTrim !== "" && !Number.isInteger(rVal)) return "invalid";
+    if ((rVal ?? null) !== (saved.runtime_min ?? null)) out.runtime_min = rVal;
+
+    return out;
+  }
+
+  const dirty = (() => {
+    const c = changedFields();
+    return c === "invalid" ? true : Object.keys(c).length > 0;
+  })();
+
+  async function save() {
+    const fields = changedFields();
+    if (fields === "invalid") {
+      setState("error");
+      setErrorMsg("Year and runtime must be whole numbers.");
+      return;
+    }
+    if (Object.keys(fields).length === 0) return;
+    setState("saving");
+    setErrorMsg(null);
+    try {
+      const res = await fetch(`/api/titles/${titleId}/metadata`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(fields),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        title?: TitleMetadata;
+        error?: string;
+      };
+      if (!res.ok || !json.ok || !json.title) {
+        setState("error");
+        setErrorMsg(json.error ?? `request failed (${res.status})`);
+        return;
+      }
+      // Settle to server truth (it returns the full row after the partial write).
+      const t = json.title;
+      setSaved({
+        synopsis: t.synopsis,
+        year: t.year,
+        runtime_min: t.runtime_min,
+        director: t.director,
+        starring_csv: t.starring_csv,
+      });
+      setSynopsis(t.synopsis ?? "");
+      setYear(t.year != null ? String(t.year) : "");
+      setRuntime(t.runtime_min != null ? String(t.runtime_min) : "");
+      setDirector(t.director ?? "");
+      setStarring(t.starring_csv ?? "");
+      setState("saved");
+    } catch (err) {
+      setState("error");
+      setErrorMsg(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  const inputCls =
+    "w-full rounded-md border border-white/10 bg-black/30 px-3 py-2 text-body-sm text-moonbeem-ink focus:border-moonbeem-pink focus:outline-none";
+  const labelCls = "text-caption text-moonbeem-ink-subtle";
+  const onAnyChange = () => {
+    if (state !== "idle") setState("idle");
+  };
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+      <h2 className="m-0 text-body font-medium text-moonbeem-ink">Details</h2>
+      <p className="mt-1 text-caption text-moonbeem-ink-subtle">
+        Core metadata shown on the{" "}
+        <code className="font-mono">/t/{titleSlug}</code> About tab. Edit any
+        field and Save — only changed fields are written.
+      </p>
+
+      <div className="mt-5 flex flex-col gap-4">
+        <label className="flex flex-col gap-1">
+          <span className={labelCls}>Synopsis</span>
+          <textarea
+            value={synopsis}
+            onChange={(e) => {
+              setSynopsis(e.target.value);
+              onAnyChange();
+            }}
+            rows={4}
+            placeholder="The About-tab description paragraph."
+            className={inputCls}
+          />
+        </label>
+
+        <div className="grid grid-cols-2 gap-4">
+          <label className="flex flex-col gap-1">
+            <span className={labelCls}>Year</span>
+            <input
+              type="number"
+              inputMode="numeric"
+              value={year}
+              onChange={(e) => {
+                setYear(e.target.value);
+                onAnyChange();
+              }}
+              placeholder="2026"
+              className={inputCls}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className={labelCls}>Runtime (minutes)</span>
+            <input
+              type="number"
+              inputMode="numeric"
+              value={runtime}
+              onChange={(e) => {
+                setRuntime(e.target.value);
+                onAnyChange();
+              }}
+              placeholder="12"
+              className={inputCls}
+            />
+          </label>
+        </div>
+
+        <label className="flex flex-col gap-1">
+          <span className={labelCls}>Director</span>
+          <input
+            type="text"
+            value={director}
+            onChange={(e) => {
+              setDirector(e.target.value);
+              onAnyChange();
+            }}
+            placeholder="Jane Doe"
+            className={inputCls}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <span className={labelCls}>
+            Starring{" "}
+            <span className="text-moonbeem-ink-subtle">
+              (comma-separated: Name, Name, Name)
+            </span>
+          </span>
+          <input
+            type="text"
+            value={starring}
+            onChange={(e) => {
+              setStarring(e.target.value);
+              onAnyChange();
+            }}
+            placeholder="Actor One, Actor Two"
+            className={inputCls}
+          />
+        </label>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={save}
+            disabled={!dirty || state === "saving"}
+            className="rounded-md bg-moonbeem-pink px-4 py-2 text-body-sm font-semibold text-moonbeem-navy transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {state === "saving" ? "Saving…" : "Save details"}
+          </button>
+          {state === "saved" && !dirty && (
+            <span className="text-caption text-emerald-300">Saved ✓</span>
+          )}
+        </div>
+        {errorMsg && (
+          <p className="m-0 text-caption text-moonbeem-magenta">{errorMsg}</p>
+        )}
+      </div>
+    </section>
+  );
+}
+
 type SettingsState = "idle" | "saving" | "error";
 
 function SettingsTab({
@@ -1552,6 +1785,7 @@ function SettingsTab({
   slug,
   titleName,
   initialPosterUrl,
+  initialMetadata,
   initialIsActive,
   initialIsPublic,
   initialPartnerId,
@@ -1563,6 +1797,7 @@ function SettingsTab({
   slug: string;
   titleName: string;
   initialPosterUrl: string | null;
+  initialMetadata: TitleMetadata;
   initialIsActive: boolean;
   initialIsPublic: boolean;
   initialPartnerId: string | null;
@@ -1703,6 +1938,12 @@ function SettingsTab({
       />
 
       <EpisodesEditor titleId={titleId} titleSlug={slug} />
+
+      <DetailsEditor
+        titleId={titleId}
+        titleSlug={slug}
+        initialMetadata={initialMetadata}
+      />
 
       <section className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
         <h2 className="m-0 text-body font-medium text-moonbeem-ink">

--- a/src/app/admin/titles/[slug]/page.tsx
+++ b/src/app/admin/titles/[slug]/page.tsx
@@ -78,7 +78,7 @@ export default async function AdminTitleDetailPage({
   const { data: title, error: titleErr } = await supabase
     .from("titles")
     .select(
-      "id, slug, title, is_active, is_public, partner_id, poster_url, deleted_at, partners:partner_id(name, slug)",
+      "id, slug, title, is_active, is_public, partner_id, poster_url, synopsis, year, runtime_min, director, starring_csv, deleted_at, partners:partner_id(name, slug)",
     )
     .eq("slug", slug)
     .maybeSingle();
@@ -95,6 +95,11 @@ export default async function AdminTitleDetailPage({
     is_public: boolean;
     partner_id: string | null;
     poster_url: string | null;
+    synopsis: string | null;
+    year: number | null;
+    runtime_min: number | null;
+    director: string | null;
+    starring_csv: string | null;
     deleted_at: string | null;
     partners: { name: string; slug: string } | null;
   };
@@ -249,6 +254,13 @@ export default async function AdminTitleDetailPage({
       partnerSlug={t.partners?.slug ?? null}
       hasPartner={!!t.partner_id}
       posterUrl={t.poster_url}
+      metadata={{
+        synopsis: t.synopsis,
+        year: t.year,
+        runtime_min: t.runtime_min,
+        director: t.director,
+        starring_csv: t.starring_csv,
+      }}
       allPartners={allPartners}
       fanEdits={fanEdits}
       clips={clips}

--- a/src/app/api/titles/[id]/metadata/route.ts
+++ b/src/app/api/titles/[id]/metadata/route.ts
@@ -1,0 +1,164 @@
+// PATCH /api/titles/[id]/metadata — edit a created title's core rendered
+// metadata (the 5 fields the About tab actually reads). Net-new, title-scoped
+// (NOT /api/admin), so owning-partner-admins are authorized via the OR gate —
+// mirrors the poster route, NOT an extension of the super-admin-only
+// /api/admin/titles/[slug].
+//
+// Presentation/metadata-only, money-rail-free, Mux-independent. Partial PATCH:
+// only provided fields are written (editing just the synopsis leaves the rest).
+//
+// Authorization: authorizeTitleMutation(user.id, titleId) — super_admin OR the
+// owning-partner-admin. Same 401/404/403 mapping as poster/episodes/thumbnails.
+
+import { NextResponse, type NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { getUser } from "@/lib/dal";
+import { enforce } from "@/lib/ratelimit";
+import { createServiceRoleClient } from "@/lib/supabase/service";
+import { authorizeTitleMutation } from "@/lib/auth/title-mutation";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// EXACTLY the 5 rendered + in-Title-type fields. tagline/overview/genres are
+// DEAD columns (rendered by nothing) and are NOT accepted — an unknown field in
+// the body is rejected, not silently dropped. runtime_min (not the dead
+// runtime_mins duplicate) is the one the About meta line reads.
+const ALLOWED_FIELDS = new Set([
+  "synopsis",
+  "year",
+  "runtime_min",
+  "director",
+  "starring_csv",
+]);
+
+const MAX_SYNOPSIS = 2000;
+const MAX_DIRECTOR = 500;
+const MAX_STARRING = 500;
+const MIN_YEAR = 1888; // first film
+const MAX_YEAR = new Date().getFullYear() + 1; // allow next-year announcements
+
+// Free-text: trim, cap length, empty → NULL. Returns the value or an error code.
+function cleanText(
+  raw: unknown,
+  max: number,
+): { ok: true; value: string | null } | { ok: false } {
+  if (raw === null) return { ok: true, value: null };
+  if (typeof raw !== "string") return { ok: false };
+  const t = raw.trim();
+  if (t.length === 0) return { ok: true, value: null };
+  if (t.length > max) return { ok: false };
+  return { ok: true, value: t };
+}
+
+// Integer in [min,max], or null when explicitly cleared. Rejects non-integers
+// and out-of-range. Accepts a numeric string (form inputs) or a number.
+function cleanInt(
+  raw: unknown,
+  min: number,
+  max: number,
+): { ok: true; value: number | null } | { ok: false } {
+  if (raw === null || raw === "") return { ok: true, value: null };
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isInteger(n) || n < min || n > max) return { ok: false };
+  return { ok: true, value: n };
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const user = await getUser();
+  if (!user) {
+    return NextResponse.json({ error: "not_authenticated" }, { status: 401 });
+  }
+  const rl = await enforce("partnerWrites", user.id, "titles/metadata");
+  if (!rl.ok) return rl.response;
+
+  const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json({ error: "title_not_found" }, { status: 404 });
+  }
+
+  // AUTHORIZE FIRST — same gate + mapping as the poster route.
+  const authz = await authorizeTitleMutation(user.id, id);
+  if (!authz.ok) {
+    const status =
+      authz.reason === "not_authenticated"
+        ? 401
+        : authz.reason === "title_not_found"
+          ? 404
+          : 403;
+    return NextResponse.json({ error: authz.reason }, { status });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  // Reject unknown fields (don't silently accept tagline/etc.).
+  const keys = Object.keys(body);
+  const unknown = keys.filter((k) => !ALLOWED_FIELDS.has(k));
+  if (unknown.length > 0) {
+    return NextResponse.json(
+      { error: "unknown_field", fields: unknown },
+      { status: 400 },
+    );
+  }
+  if (keys.length === 0) {
+    return NextResponse.json({ error: "no_fields" }, { status: 400 });
+  }
+
+  // Build the update from ONLY the provided fields (partial PATCH).
+  const update: Record<string, string | number | null> = {};
+
+  if ("synopsis" in body) {
+    const r = cleanText(body.synopsis, MAX_SYNOPSIS);
+    if (!r.ok) return NextResponse.json({ error: "invalid_synopsis" }, { status: 400 });
+    update.synopsis = r.value;
+  }
+  if ("director" in body) {
+    const r = cleanText(body.director, MAX_DIRECTOR);
+    if (!r.ok) return NextResponse.json({ error: "invalid_director" }, { status: 400 });
+    update.director = r.value;
+  }
+  if ("starring_csv" in body) {
+    const r = cleanText(body.starring_csv, MAX_STARRING);
+    if (!r.ok) return NextResponse.json({ error: "invalid_starring_csv" }, { status: 400 });
+    update.starring_csv = r.value;
+  }
+  if ("year" in body) {
+    const r = cleanInt(body.year, MIN_YEAR, MAX_YEAR);
+    if (!r.ok) return NextResponse.json({ error: "invalid_year" }, { status: 400 });
+    update.year = r.value;
+  }
+  if ("runtime_min" in body) {
+    const r = cleanInt(body.runtime_min, 1, 100000);
+    if (!r.ok) return NextResponse.json({ error: "invalid_runtime_min" }, { status: 400 });
+    update.runtime_min = r.value;
+  }
+
+  // Write via service-role (authorization already enforced in-app). Scope by PK.
+  const supabase = createServiceRoleClient();
+  const { data: updated, error } = await supabase
+    .from("titles")
+    .update(update)
+    .eq("id", id)
+    .select("id, slug, synopsis, year, runtime_min, director, starring_csv")
+    .maybeSingle();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  if (!updated) {
+    return NextResponse.json({ error: "title_not_found" }, { status: 404 });
+  }
+
+  // The About tab reads live (no static cache / revalidate on /t/[slug]), so
+  // this isn't strictly required — but revalidate to drop any CDN/router cache.
+  revalidatePath(`/t/${updated.slug}`);
+
+  return NextResponse.json({ ok: true, title: updated, via: authz.via });
+}

--- a/src/components/AboutCredits.tsx
+++ b/src/components/AboutCredits.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/lib/queries/titles";
 
 type Props = {
-  title: Pick<Title, "cast_members" | "crew">;
+  title: Pick<Title, "cast_members" | "crew" | "starring_csv">;
 };
 
 function PersonRow({ label, names }: { label: string; names: string[] }) {
@@ -41,6 +41,14 @@ export default function AboutCredits({ title }: Props) {
   const composers = getComposers(title.crew);
   const cast = getTopCast(title.cast_members, 5);
 
+  // Fallback cast list from the free-text starring_csv (the metadata editor
+  // writes this for manually-created titles that have no structured
+  // cast_members). Used ONLY when there's no structured cast.
+  const starringNames = (title.starring_csv ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
   const anyCrew =
     directors.length +
       writers.length +
@@ -49,7 +57,7 @@ export default function AboutCredits({ title }: Props) {
       composers.length >
     0;
 
-  if (!anyCrew && cast.length === 0) return null;
+  if (!anyCrew && cast.length === 0 && starringNames.length === 0) return null;
 
   return (
     <div className="flex flex-col gap-2 text-body-sm leading-relaxed max-w-prose w-full text-left">
@@ -76,6 +84,13 @@ export default function AboutCredits({ title }: Props) {
         names={composers}
       />
       <PersonRow label="Cast" names={cast} />
+      {/* Fallback: plain "Starring" line from starring_csv when there's no
+          structured cast_members. Real cast always wins (gated on cast empty). */}
+      {cast.length === 0 && starringNames.length > 0 && (
+        <p className="text-body text-moonbeem-ink-muted m-0">
+          Starring {starringNames.join(", ")}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
**Draft — do not merge.** A Details form in the Settings tab to edit a title's About-tab metadata. Reuses `authorizeTitleMutation`. Presentation-only.

- `PATCH /api/titles/[id]/metadata` — net-new, title-scoped (not `/api/admin`); gate + 401/404/403 mapping same as poster. **Partial PATCH** (only changed fields). 5 fields only: `synopsis, year, runtime_min, director, starring_csv`. Unknown fields (tagline/overview/genres = dead columns) → 400. Validation: text caps + empty→NULL; year 1888..next-year integer; runtime_min positive integer.
- UI: `DetailsEditor` — 5 prefilled fields, starring labeled comma-separated.

Validation verified headlessly; tsc + build clean.

### Preview (super-admin = you)
- [ ] `/admin/titles/watch-hill-2026` → Settings → **Details**: set runtime, director, starring (+ tweak synopsis/year) → Save → About tab on `/t/watch-hill-2026` shows year · runtime · director + cast + synopsis (sparse → complete)
- [ ] edit ONLY synopsis → others unchanged (partial PATCH)
- [ ] bad year (3000) / runtime 0 → rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)